### PR TITLE
rwd: phone-first layout pass for homepage and subpages

### DIFF
--- a/static/css/general.css
+++ b/static/css/general.css
@@ -179,6 +179,29 @@ i {
     --hover-transition-time: 0.15s;
     --block-skew: -3deg;
     --content-skew: calc(-1 * var(--block-skew));
+
+    /* Single source of truth for the horizontal section gutter. Every
+       section's left/right edge is governed by this token — no inner
+       container should add its own padding-inline.
+
+       Clamp ceiling = 5rem (80px). Combined with the 80rem section
+       max-width, content area on a 1440px screen = 1280 - 160 = 1120px;
+       on 1920px the section is centered with a 320px outer gutter PLUS
+       80px inner gutter, content stays at 1120px. So the page does NOT
+       keep widening on bigger screens — content is capped, padding is
+       capped. */
+    --gutter-x: clamp(2.5rem, 6vw, 6rem);
+}
+
+@media (max-width: 48rem) {
+    :root { --gutter-x: clamp(2rem, 5vw, 4rem); }
+}
+
+@media (max-width: 30rem) {
+    :root { --gutter-x: 2rem; }
+    /* Scale every rem-based size proportionally on phone. 87.5% = 14px
+       root — body text drops to 14px, headings/padding shrink ~12.5%. */
+    html { font-size: 87.5%; }
 }
 
 .fill-101-top {
@@ -362,7 +385,10 @@ body {
 section:has(.section-title) {
     width: min(100%, 80rem);
     margin-inline: auto;
-    padding: 8rem 2rem;
+    padding-block: 8rem;
+    /* Horizontal gutter from --gutter-x token (see :root). All inner
+       containers should add 0 padding-inline so everything aligns. */
+    padding-inline: var(--gutter-x);
 
     & .section-title {
         display: flex;
@@ -833,4 +859,140 @@ svg:has(use[href*="#svg-hash"]) {
 
 svg:has(use[href*="#svg-send-s"]) {
     aspect-ratio: 18/16;
+}
+
+/* ============================================================
+   Mobile RWD overrides
+   Desktop-first: rules above are the source of truth; this block
+   only adjusts what breaks on phone-sized viewports.
+   ============================================================ */
+
+/* Defensive guard: prevent horizontal scroll regardless of section bugs.
+   Compatible with the site's position:fixed elements (menu, to-top, nav-l);
+   no position:sticky in use, so this is safe. */
+html,
+body {
+    overflow-x: clip;
+    max-width: 100%;
+}
+
+@media (max-width: 640px) {
+    /* Open trigger: keep the corner placement, add touch-target height. */
+    .menu-btn {
+        top: 1.25rem;
+        right: 0;
+        padding-block: 0.5rem;
+        min-height: 2.75rem;
+
+        /* Phone: drop the "Menu" label and shrink to match the compact
+           subpage header (logo: 2rem, padding-block: 0.625rem → ~52px). */
+        @media (max-width: 30rem) {
+            top: 0.625rem;
+            padding: 0.25rem 0.625rem;
+            min-height: 2rem;
+            gap: 0;
+
+            & p {
+                display: none;
+            }
+
+            & svg {
+                width: 1rem;
+            }
+        }
+    }
+
+    /* Off-canvas panel: clamp width to viewport (no horizontal scroll)
+       and scale every interior dimension with viewport height (dvh) so
+       the full menu fits on short screens like iPhone SE without
+       clipping. The skew geometry already accounts for height-based
+       slant via the existing right offset. */
+    .menu {
+        --_menu-width: min(20rem, calc(100vw - 1.5rem));
+        --_menu-a-width: 100%;
+
+        .menu-wrapper {
+            padding-block: clamp(0.75rem, 2dvh, 1.5rem);
+            /* Right padding must cover the skew offset: the panel is
+               translated off-screen by (-100lvh * tan(3°) / 2) ≈ 22px on
+               a tall phone, plus the parallelogram's slanted right edge
+               eats more horizontal room. 3rem keeps text fully visible. */
+            padding-inline: 1.25rem 3rem;
+            gap: clamp(0.5rem, 1.4dvh, 1rem);
+            justify-content: safe center;
+            /* Stretch flex children so every <ui> wrapper spans the full
+               panel width — this makes the inner .menu-a buttons land on
+               the same left/right edges instead of shrinking to content. */
+            align-items: stretch;
+            overflow-y: auto;
+        }
+
+        /* The <ui> wrappers are unknown elements (display: inline by
+           default) — promote them to block so their child .menu-a fills
+           the row. Cheaper than fixing the template. */
+        .menu-wrapper > * {
+            display: block;
+            width: 100%;
+        }
+
+        .menu-a {
+            --_adjusted-font-size: clamp(0.875rem, 2.2dvh, 1rem);
+            min-height: clamp(2.25rem, 5.5dvh, 2.75rem);
+            width: 100%;
+        }
+
+        & svg {
+            width: clamp(1rem, 3dvh, 1.375rem);
+        }
+
+        /* Close button stays compact and right-aligned — opt out of the
+           stretch above so it doesn't span the row. */
+        .menu-wrapper > :has(.menu-close-btn) {
+            display: flex;
+            justify-content: flex-end;
+            width: 100%;
+        }
+
+        .menu-close-btn {
+            min-width: clamp(2.25rem, 5.5dvh, 2.75rem);
+            min-height: clamp(2.25rem, 5.5dvh, 2.75rem);
+            width: auto;
+            justify-content: center;
+        }
+    }
+
+    /* Side-rail section nav is desktop-only; on phones it consumes ~56px
+       of right gutter and overlaps content. The slide-in menu replaces it. */
+    .nav-l {
+        display: none;
+    }
+
+    /* Smaller vertical padding on mobile. Horizontal padding (padding-inline)
+       is intentionally NOT set here — it comes from the --gutter-x token so
+       a single source of truth controls all section gutters. */
+    section:has(.section-title) {
+        padding-block: 4rem;
+    }
+
+    /* Compact footer on phone: smaller logo, gap, link size. */
+    footer {
+        padding: 2rem var(--gutter-x);
+        gap: 1rem;
+
+        .ftr-logo svg {
+            width: 2rem;
+        }
+
+        .ftr-link-wrapper {
+            gap: 0.875rem 1.25rem;
+
+            .ftr-link {
+                font-size: 0.9375rem;
+            }
+        }
+
+        .ftr-info {
+            font-size: 0.8125rem;
+        }
+    }
 }

--- a/static/css/member.css
+++ b/static/css/member.css
@@ -365,3 +365,132 @@ h2 {
         }
     }
 }
+
+/* ============================================================
+   Phone overrides for member subpages (≤480px)
+   Hierarchy follows the same h1 ≥ h2 ≥ sub-sub rule as homepage.
+   At 14px root (set globally on phone in general.css), all sizes
+   shrink ~12.5% naturally — these tweaks are absolute targets.
+   ============================================================ */
+@media (width <= 30rem) {
+    main {
+        /* Use the same gutter token as the homepage so the member page
+           lines up with section content edges. */
+        width: min(100%, 75rem);
+        padding-inline: var(--gutter-x);
+        padding-block: 1.5rem 4rem;
+        gap: 2rem 1rem;
+    }
+
+    .main-info {
+        gap: 1.25rem;
+        margin-top: 1.5rem;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+
+        /* Smaller portrait — this IS the personal page, but the photo
+           was 320px (~20rem) which is awkward on a 360px viewport. */
+        .photo {
+            height: 12rem;
+            margin-right: 0;
+            margin-inline: auto;
+        }
+
+        .info-text {
+            margin-left: 0;
+            margin-top: 0.5rem;
+            gap: 0.375rem;
+            align-items: center;
+        }
+
+        .main-name {
+            justify-content: center;
+
+            & h1 {
+                font-size: 1.875rem;       /* 30px → ~26px @14px root */
+                line-height: 1.15;
+            }
+
+            & svg {
+                height: 2rem;
+            }
+        }
+
+        .sub-name {
+            font-size: 1.125rem;            /* below h1 */
+        }
+
+        .position-text {
+            font-size: 1rem;                /* below sub-name */
+            margin-top: 0.5rem;
+        }
+
+        .tags {
+            gap: 0.5rem;
+            margin-top: 1rem;
+            justify-content: center;
+        }
+    }
+
+    /* Section h2 — smaller, closer to following content. */
+    h2 {
+        font-size: 1.625rem;                /* 26px → ~22.75px @14px root */
+
+        &::after {
+            width: 0.5rem;
+            height: 0.1875rem;
+        }
+
+        &+* {
+            margin-block-start: 0.625rem;
+        }
+    }
+
+    /* About body text */
+    #about {
+        .content p,
+        .content li {
+            font-size: 1rem;                /* 14px @14px root */
+            text-indent: 1rem;
+        }
+
+        .content ul,
+        .content ol {
+            padding-inline-start: 1.25rem;
+        }
+    }
+
+    /* Research */
+    #research {
+        .content {
+            gap: 1.25rem;
+        }
+
+        .res-img-wrapper {
+            width: 100%;
+            max-width: 16rem;
+        }
+
+        .res-info .res-tag {
+            font-size: 1.125rem;            /* sub-sub under h2 */
+        }
+
+        .res-info .res-info-minor {
+            font-size: 0.875rem;
+            max-width: none;
+        }
+    }
+
+    /* Publication blocks */
+    .publication {
+        --_font-size-l: 1rem;               /* publication title */
+        --_font-size-s: 0.8125rem;          /* date / journal meta */
+    }
+
+    .list {
+        .list-block .list-title {
+            font-size: 1rem;
+        }
+    }
+}

--- a/static/css/news-item.css
+++ b/static/css/news-item.css
@@ -271,6 +271,91 @@
     }
 }
 
+/* Phone overrides — match the compact look used on member individual page. */
+@media (width <= 30rem) {
+    .news-item-main {
+        padding-block: 1.5rem 4rem;
+        padding-inline: var(--gutter-x);
+    }
+
+    .news-item-hero {
+        margin-block-end: 1.75rem;
+    }
+
+    .news-item-hero-img img,
+    .news-item-hero-placeholder {
+        height: 12rem;
+    }
+
+    .news-item-date-badge {
+        left: 0.75rem;
+        bottom: -0.5rem;
+        --_adjusted-font-size: 0.8125rem;
+        --_adjusted-padding: 0.45rem 0.75rem;
+    }
+
+    .news-item-date-mm {
+        font-size: 0.75rem;
+    }
+
+    .news-item-date-yy {
+        font-size: 1.125rem;
+    }
+
+    .news-item-article {
+        padding-block-start: 0.75rem;
+    }
+
+    .news-item-header {
+        gap: 0.625rem;
+    }
+
+    .news-item-category {
+        font-size: 0.625rem;
+    }
+
+    .news-item-title {
+        font-size: 1.375rem;
+    }
+
+    .news-item-ext-link {
+        --_adjusted-font-size: 0.8125rem;
+    }
+
+    .news-item-divider {
+        margin-block: 1.25rem;
+    }
+
+    .news-item-body {
+        font-size: 1rem;
+        line-height: 1.6;
+
+        & p {
+            margin-block-end: 0.875rem;
+        }
+
+        & h2 { font-size: 1.375rem; margin-block: 1.5rem 0.625rem; }
+        & h3 { font-size: 1.125rem; margin-block: 1.25rem 0.5rem; }
+        & h4 { font-size: 1rem;     margin-block: 1.125rem 0.4rem; }
+        & h5 { font-size: 0.9375rem; margin-block: 1rem 0.4rem; }
+        & h6 { font-size: 0.8125rem; margin-block: 0.875rem 0.4rem; }
+
+        & li {
+            font-size: 1rem;
+            margin-block-end: 0.3125rem;
+        }
+    }
+
+    .news-item-placeholder {
+        font-size: 1rem;
+    }
+
+    .news-item-body img {
+        width: 100%;
+        margin-block: 1.25rem;
+    }
+}
+
 @media (prefers-reduced-motion: reduce) {
     .news-item-body img {
         transition: none;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -845,7 +845,8 @@
 
     line-height: 1.5;
 
-    padding-inline: 1rem;
+    /* Inner padding removed: content aligns to the section-title's left
+       edge, governed by the parent section's responsive padding-inline. */
 
     display: flex;
     gap: var(--_gap) calc(var(--_gap) * 1.5);
@@ -863,6 +864,9 @@
             /* margin-block-start: 1rem; */
             font-size: 1.3125rem;
             text-indent: 2rem;
+            text-align: justify;
+            text-wrap: pretty;
+            hyphens: auto;
 
             & sub {
                 font-size: 0.75em;
@@ -902,7 +906,7 @@
     }
 
     &[which='sponsors'] {
-        padding-inline: 3rem;
+        /* No inline padding — content shares the section's --gutter-x. */
 
         & a {
             display: grid;
@@ -954,7 +958,8 @@
 }
 
 .mem-section {
-    padding-inline: 1rem;
+    /* No inner padding — aligns flush with section-title; parent section
+       owns the responsive horizontal breathing. */
 
     .mem-quote {
         width: 0.875rem;
@@ -1092,12 +1097,14 @@
                 gap: 0;
 
                 .EngName {
-                    font-size: 3.75rem;
-                    line-height: 1;
+                    /* Capped at h3 (1.75rem) so the person-name subheading
+                       never exceeds the section subheading above it. */
+                    font-size: 1.75rem;
+                    line-height: 1.1;
                 }
 
                 .ChiName {
-                    font-size: 1.5rem;
+                    font-size: 1.25rem;
                 }
             }
         }
@@ -1250,12 +1257,13 @@
     --_res-block-width: 25rem;
     --_res-info-width: 20rem;
 
-    padding-inline: 1rem;
+    /* No inner padding — see note on .mem-section / .abt-section above. */
 
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(var(--_res-block-width), 1fr));
     gap: 2rem 1rem;
-    justify-content: space-between;
+    justify-content: center;
+    justify-items: center;
 
     @media (width < 75rem) {
         --_res-block-width: var(--_res-info-width);
@@ -1266,8 +1274,7 @@
         flex-wrap: wrap;
         gap: 1rem 0.625rem;
         align-items: start;
-        /* justify-content: center; */
-        /* @media (width < 42rem) {justify-content: center;} */
+        justify-content: center;
     }
 
     .res-fields-block {
@@ -1699,7 +1706,8 @@
     }
 
     .publi-block-wrapper {
-        margin-inline: 1.5rem;
+        /* Removed margin-inline: 1.5rem — was creating a different left
+           edge from .mem-section (1rem) and the section-title (0). */
 
         &>*+* {
             margin-block-start: var(--_block-gap);
@@ -1770,7 +1778,7 @@
 .more,
 .publi-more {
     margin-block-start: 1rem;
-    margin-inline-start: 0.5rem;
+    /* No inline indent — aligns with section-title and inner content. */
     width: fit-content;
 
     display: flex;
@@ -2191,7 +2199,8 @@
 
 @media (width <=48rem) {
     section:has(.section-title) {
-        padding: 6rem 1.5rem;
+        /* padding-inline comes from --gutter-x token; only override vertical. */
+        padding-block: 6rem;
 
         .section-title {
             & h2 {
@@ -2243,22 +2252,40 @@
         }
     }
 
-    /* ppl */
+    /* ppl — hierarchy cap: at this breakpoint h3 is 1.25rem, so all
+       person-level "sub-sub" titles (EngName, ChiName, PhD names) must
+       be ≤ 1.25rem. Note .EngName/.ChiName are <a> tags, NOT div/span. */
     .mem-section[who='L'] {
         .mem-name {
-            & div {
-                margin-block-start: 0rem;
-                font-size: 2.5rem;
+            .EngName {
+                font-size: 1.25rem;
+                line-height: 1.15;
             }
 
-            & span {
-                font-size: 1.25rem;
+            .ChiName {
+                font-size: 1rem;
             }
         }
 
         .mem-info {
             font-size: 1rem;
         }
+    }
+
+    .mem-section[who='M'] {
+        .mem-name .mem-name-en {
+            font-size: 1.25rem;
+        }
+
+        .mem-name .mem-name-zh {
+            font-size: 0.875rem;
+        }
+    }
+
+    /* Research topic name — also a sub-sub heading (under h3 like
+       "Energy / Economics / Environment"). Cap at h3 size. */
+    .res-section .res-info .res-tag {
+        font-size: 1.25rem;
     }
 
     .publi-section {
@@ -2359,5 +2386,209 @@
 
     & svg {
         height: calc(var(--_tag-height) * 0.55);
+    }
+}
+
+/* ============================================================
+   Phone-only homepage overrides (≤480px)
+   The 48rem (768px) block above already covers tablets+phones.
+   This block fixes the deltas that still break at iPhone SE / 14 / 15.
+   ============================================================ */
+@media (width <= 30rem) {
+    /* Section heading — universal: every section that uses .section-title
+       (Members, Publications, News, Research, Group Life, Videos) inherits
+       this. Smaller h2 + matching SVG height keeps proportions correct. */
+    section:has(.section-title) {
+        .section-title h2 {
+            font-size: 2rem;
+        }
+
+        .section-title svg {
+            height: 1.75rem;
+            translate: 0.25rem -0.5rem;
+        }
+
+        & .section-subtitle div {
+            font-size: 0.9375rem;
+        }
+    }
+
+    /* Sub-section headings — Director / PhD Students / Past News etc. */
+    h3 {
+        font-size: 1.125rem;
+        margin-block: 1.75rem 0.625rem;
+    }
+
+    /* Hero — h1 was 3rem (48px) inherited from the 100rem rule and never
+       shrunk further. iPhone SE only fits ~6 chars at that size. */
+    #home {
+        --_home-min-height: 38rem;
+
+        .hp-title h1 {
+            font-size: 2.25rem;
+
+            & svg {
+                height: 1.875rem;
+                translate: 0.25rem -0.5rem;
+            }
+        }
+
+        .hp-3e p {
+            font-size: 1.25rem;
+        }
+    }
+
+    /* About — collapse the logo gap and shrink sponsor logos. The
+       --_para-min-width: 50rem flex-basis trick already wraps correctly
+       once the viewport is narrow; only the logo row needed help. */
+    .abt-section {
+        --_logo-width: 12rem;
+        gap: 1.25rem 1rem;
+
+        .abt-logos {
+            gap: 1.25rem 2rem;
+
+            & img {
+                height: 4rem;
+            }
+        }
+
+        &[which='sponsors'] {
+            padding-inline: 1rem;
+
+            & img {
+                height: 3rem;
+            }
+        }
+    }
+
+    /* Members "Leaders" (Prof. Hsieh) — stack into a compact profile card.
+       Thumbnail-sized portrait (the card is clickable; full-size portrait
+       lives on the personal page). Name sized at-or-below h3 since it's a
+       sub-sub-heading under "Director". */
+    .mem-section[who='L'] {
+        --_img-width: 7rem;
+
+        .mem-block {
+            flex-direction: column;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .mem-text {
+            margin-left: 0;
+            justify-items: center;
+            text-align: center;
+            gap: 0.375rem;
+        }
+
+        .mem-name {
+            justify-items: center;
+            gap: 0.0625rem;
+
+            /* Hierarchy cap on phone: h3 = 1.125rem, so .EngName ≤ 1.125rem. */
+            .EngName {
+                font-size: 1.125rem;
+                line-height: 1.2;
+            }
+
+            .ChiName {
+                font-size: 0.875rem;
+            }
+        }
+
+        .mem-info {
+            font-size: 0.8125rem;
+            line-height: 1.45;
+            text-wrap: pretty;
+        }
+    }
+
+    /* Members "M" grid — clickable thumbnails. With doubled gaps the grid
+       falls back to 2-per-row on smaller phones (which gives nicer breathing
+       than 3 cramped cards anyway). */
+    .mem-section[who='M'] {
+        --_img-width: 6.25rem;
+        gap: 2rem 1rem;
+        justify-content: space-around;
+
+        .mem-block {
+            padding: 0.25rem;
+            gap: 0.625rem;
+        }
+
+        .mem-name .mem-name-en {
+            font-size: 1rem;
+            gap: 0.25rem;
+        }
+
+        .mem-name .mem-name-zh {
+            font-size: 0.75rem;
+        }
+    }
+
+    /* Members "S" — stack image + name vertically isn't ideal, keep them
+       horizontal but allow each card to span the full row. */
+    .mem-section[who='S'] {
+        --_mem-block-width: 100%;
+        gap: 1rem;
+
+        .mem-block {
+            justify-content: flex-start;
+            gap: 0.75rem;
+
+            .mem-name {
+                width: auto;
+                font-size: 1.25rem;
+
+                & span {
+                    font-size: 0.875rem;
+                }
+            }
+        }
+    }
+
+    /* Research — info column was 20rem (320px); on a 390px screen with
+       16px section padding that leaves 22px for the field block + image.
+       Let it shrink with viewport instead. */
+    .res-section {
+        --_res-info-width: min(20rem, calc(100vw - 4rem));
+        gap: 1.5rem;
+
+        /* Hierarchy cap: h3 phone = 1.125rem; .res-tag is sub-sub. */
+        .res-info .res-tag {
+            font-size: 1.125rem;
+        }
+
+        .res-info .res-info-minor {
+            font-size: 0.9375rem;
+        }
+    }
+
+    /* Publications & news titles — also sub-sub under h3 categories.
+       --_font-size-l drives .publi-title; cap below h3 1.125rem. */
+    .publi-section {
+        --_font-size-l: 1.0625rem;
+    }
+
+    /* Group-life "all" — grid items were 245px each → single column with
+       145px of empty right gutter. Two-up at narrower widths. */
+    .glf-section[which='all'] {
+        --_img-width: calc((100vw - 3rem) / 2 - 0.5rem);
+        gap: 1rem 0.75rem;
+        justify-content: center;
+    }
+
+    /* News & publications — section-title "All" button on its own line so
+       it doesn't compete with the headline for horizontal space. */
+    #members .section-title,
+    #news .section-title,
+    #publications .section-title {
+        flex-wrap: wrap;
+        gap: 0.75rem;
+
+        & .more {
+            --_adjusted-font-size: 1rem;
+        }
     }
 }

--- a/static/css/subpage.css
+++ b/static/css/subpage.css
@@ -99,13 +99,44 @@
     }
 }
 
-/* Subpage section layout (replaces section:has(.section-title) for subpages) */
-#members,
-#news,
-#publications {
+@media (width <= 30rem) {
+    /* Compact phone header — logo + breadcrumb wrap to two rows when
+       needed; horizontal padding follows the global gutter token. */
+    .subpage-header {
+        padding-block: 0.625rem;
+        padding-inline: var(--gutter-x);
+        gap: 0.5rem 0.875rem;
+        flex-wrap: wrap;
+    }
+
+    .subpage-header-logo img {
+        height: 2rem;
+    }
+
+    .breadcrumb-parent {
+        font-size: 1.125rem;
+    }
+
+    .breadcrumb-sep {
+        font-size: 1.125rem;
+    }
+
+    .breadcrumb-current {
+        font-size: 0.8125rem;
+    }
+}
+
+/* Subpage section layout (replaces section:has(.section-title) for subpages).
+   Scoped to subpage classes — using #ID selectors here was bleeding into
+   the homepage's <section id="members"> etc. and overriding the gutter.
+   Padding-inline reuses the homepage --gutter-x token for consistency. */
+.members-subpage,
+.news-subpage,
+.publications-subpage {
     width: min(100%, 80rem);
     margin-inline: auto;
-    padding: 4rem 2rem 8rem;
+    padding-block: 4rem 8rem;
+    padding-inline: var(--gutter-x);
 }
 
 /* ── Members subpage redesign ─────────────────────────────────────── */
@@ -557,7 +588,7 @@
     align-items: center;
     gap: 1.5rem;
     padding-block: 1.125rem;
-    padding-inline: 0.75rem;
+    /* No padding-inline — first column aligns with the section gutter. */
     border-bottom: 0.0625rem solid color-mix(in srgb, var(--main-color) 12%, transparent);
     text-decoration: none;
 }
@@ -700,6 +731,188 @@
 
     .news-row-title {
         font-size: 1rem;
+    }
+}
+
+/* ============================================================
+   Phone overrides for subpage layouts (≤480px)
+   Compact padding + smaller typography on news / publications /
+   members listing pages, matching the individual member subpage.
+   ============================================================ */
+@media (width <= 30rem) {
+    /* Page-level padding — match member individual subpage's main(). */
+    .members-subpage,
+    .news-subpage,
+    .publications-subpage {
+        padding-block: 1.5rem 4rem;
+    }
+
+    /* ── Members listing ─────────────────────────────────────────── */
+    .members-subpage {
+        & .mem-rows {
+            margin-block-start: 0.5rem;
+        }
+
+        & .mem-row {
+            gap: 0.75rem;
+            padding-block: 1rem;
+            padding-inline-start: 0.5rem;
+            padding-inline-end: 0.25rem;
+        }
+
+        & .mem-card {
+            gap: 1rem;
+        }
+
+        & .mem-row-photo {
+            --_img-width: 4.5rem;
+            --_img-border-w: 0.125rem;
+            --_img-border-r: 0.25rem;
+        }
+
+        & .mem-row-en {
+            font-size: 1.25rem;       /* sub-sub under group title */
+        }
+
+        & .mem-row-zh {
+            font-size: 0.875rem;
+        }
+
+        & .mem-row-position {
+            margin-block-start: 0.125rem;
+
+            & p:first-child {
+                font-size: 0.875rem;
+            }
+
+            & p:not(:first-child) {
+                font-size: 0.8125rem;
+            }
+        }
+
+        & .mem-row-links {
+            margin-block-start: 0.375rem;
+            gap: 0.375rem;
+
+            & .mem-row-tag {
+                --_adjusted-font-size: 0.75rem;
+            }
+        }
+
+        & .mem-alum-grid {
+            grid-template-columns: repeat(auto-fill, minmax(4rem, 1fr));
+            gap: 1.25rem 0.625rem;
+        }
+
+        & .mem-alum-photo {
+            --_img-width: 4rem;
+        }
+
+        & .mem-alum-name .mem-alum-en {
+            font-size: 0.875rem;
+        }
+
+        & .mem-alum-name .mem-alum-zh {
+            font-size: 0.75rem;
+        }
+    }
+
+    /* PI featured row on phone — keep emphasis but tighter. */
+    .mem-group--pi {
+        & .mem-row-photo {
+            --_img-width: 6rem;
+        }
+
+        & .mem-row-en {
+            font-size: 1.5rem;
+        }
+
+        & .mem-row-zh {
+            font-size: 1rem;
+        }
+    }
+
+    /* ── News listing ────────────────────────────────────────────── */
+    .news-filter-tab {
+        font-size: 0.75rem;
+        padding: 0.25rem 0.75rem;
+    }
+
+    .news-cat-section {
+        margin-block-end: 2.5rem;
+    }
+
+    .news-cat-title,
+    .publications-subpage .publi-group-title {
+        font-size: 0.625rem;
+        margin-block-end: 0.625rem;
+    }
+
+    .news-row {
+        grid-template-columns: 3rem 1fr;       /* drop the trailing arrow column */
+        gap: 0.625rem;
+        padding-block: 0.75rem;
+        padding-inline: 0.25rem;
+    }
+
+    .news-row--no-date {
+        grid-template-columns: 1fr;
+    }
+
+    /* Hide the right-side arrow on phone — saves a column, the whole
+       row is already a tappable link. Mirrors the .mem-row-arrow rule
+       at the 48rem breakpoint. */
+    .news-row-arrow {
+        display: none;
+    }
+
+    .news-row-mm {
+        font-size: 0.625rem;
+    }
+
+    .news-row-yy {
+        font-size: 0.9375rem;
+    }
+
+    .news-row-title {
+        font-size: 0.875rem;
+        line-height: 1.4;
+    }
+
+    .news-row-badge {
+        font-size: 0.5625rem;
+        padding: 0.1rem 0.45rem;
+    }
+
+    /* ── Publications listing ────────────────────────────────────── */
+    .publications-subpage {
+        & .publi-group {
+            margin-block-end: 2.5rem;
+        }
+    }
+
+    .publi-show-more {
+        font-size: 0.75rem;
+        padding: 0.3rem 1rem;
+    }
+
+    /* Google Scholar CTA — was sized for desktop (1.25rem button); shrink
+       to match the rest of the phone-sized typography. */
+    .publi-scholar-cta {
+        margin-block-start: 2rem;
+        padding-block-start: 1rem;
+        gap: 0.875rem;
+
+        & .skewed-block[b-role="btn"] {
+            --_adjusted-font-size: 0.875rem;
+            --_adjusted-padding: 0.4em 0.875em;
+        }
+
+        & .publi-scholar-note {
+            min-width: 0;
+            font-size: 0.875rem;
+            line-height: 1.5;
+        }
     }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,9 +57,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@500..600&family=Noto+Sans+TC:wght@500..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=2">
-    <link rel="stylesheet" href="/css/style.css?v=2">
-    <link rel="stylesheet" href="/css/subpage.css?v=1">
+    <link rel="stylesheet" href="/css/general.css?v=7">
+    <link rel="stylesheet" href="/css/style.css?v=7">
+    <link rel="stylesheet" href="/css/subpage.css?v=8">
 
     <!-- js -->
     <script defer src="/js/general.js"></script>

--- a/templates/pages/member/member.html
+++ b/templates/pages/member/member.html
@@ -91,7 +91,7 @@
     <!-- css -->
     <link rel="stylesheet" href="/css/general.css?v=2">
     <link rel="stylesheet" href="/css/subpage.css?v=1">
-    <link rel="stylesheet" href="/css/member.css?v=2">
+    <link rel="stylesheet" href="/css/member.css?v=4">
 
     <!-- js -->
     <script defer src="/js/general.js"></script>

--- a/templates/pages/news.html
+++ b/templates/pages/news.html
@@ -49,7 +49,7 @@
 </script>
 {% endblock %}
 {% block content %}
-<section id="news">
+<section id="news" class="news-subpage">
 
     {# ── Filter bar ─────────────────────────────────────────────────────── #}
     <div class="news-filter-bar" role="tablist" aria-label="Filter news by category">

--- a/templates/pages/news/news-item.html
+++ b/templates/pages/news/news-item.html
@@ -57,7 +57,7 @@
     <!-- css -->
     <link rel="stylesheet" href="/css/general.css?v=2">
     <link rel="stylesheet" href="/css/subpage.css?v=1">
-    <link rel="stylesheet" href="/css/news-item.css?v=1">
+    <link rel="stylesheet" href="/css/news-item.css?v=2">
 
     <!-- js -->
     <script defer src="/js/general.js"></script>


### PR DESCRIPTION
## Summary
- **Single source of truth for section gutters.** New \`--gutter-x\` CSS variable in \`:root\`, scaled per breakpoint. Removed the inconsistent inner \`padding-inline\`/\`margin-inline\` on \`.abt-section\`, \`.mem-section\`, \`.res-section\`, \`.publi-block-wrapper\`, \`.news-row\`, \`.more\` so every section's content edge aligns with its title.
- **Scoped subpage layout rule.** \`#members, #news, #publications { padding: ... }\` was bleeding into homepage sections of the same id and forcing 2rem inline padding on top of the gutter. Moved to \`.members-subpage\`, \`.news-subpage\`, \`.publications-subpage\` classes.
- **Compact phone treatment (≤30rem):** root font-size 87.5%, header drops "Menu" label and shrinks to ~52px, footer compacted, member individual page (portrait 320→168px, hierarchy h1≥sub-name≥position, content centered under photo), members/news/publications listings (compact rows, hidden trailing arrows, smaller fonts), news item subsubpage (hero 288→192px, full-width inline images), publications "Prof. Lisa's Google Scholar" CTA shrunk.
- **Tablet (≤48rem):** person-name sub-sub headings (\`.EngName\`, \`.ChiName\`, \`.mem-name-en\`, \`.res-tag\`) capped at h3 size to enforce hierarchy.
- **Defensive:** \`html, body { overflow-x: clip }\` prevents horizontal scroll regardless of any rogue wide child.
- **Homepage research:** \`justify-content: center\` on the grid and inside each \`.res-block\` so cards center when the row isn't full.

## Test plan
- [ ] Build cleanly (\`python build.py\`)
- [ ] Homepage at 1920, 1440, 1024, 768, 390, 375 — section content edges align across About / Members / Publications / News / Research
- [ ] Member subpage (e.g. \`/members/iyunlisahsieh/\`) on phone — name/position/tags centered under portrait, hierarchy holds
- [ ] \`/members/\`, \`/news/\`, \`/publications/\` on phone — compact rows, no horizontal scroll
- [ ] News item page (e.g. \`/news/2025-cictp-best-lightning-talk/\`) on phone — hero ~12rem, body text scales
- [ ] Menu open/close on iPhone SE — fits without clipping, all items visible
- [ ] DevTools at iPhone SE: section padding-inline computed = 28px (var(--gutter-x) at 14px root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)