### PR TITLE
Add Books section, group-life subpage, redesigned view-all CTAs

### DIFF
--- a/build.py
+++ b/build.py
@@ -89,10 +89,12 @@ if 'publications' in structures:
     home_publications = []
     for section in structures['publications']:
         new_section = section.copy()
-        # Filter items with E3: true and published status (exclude submitted/under review)
+        # Filter items with E3: true and published status (exclude submitted/under review and books)
         filtered_items = [
             item for item in section.get('items', [])
-            if item.get('E3') is True and item.get('status', 'published') == 'published'
+            if item.get('E3') is True
+            and item.get('status', 'published') == 'published'
+            and item.get('type') != 'book'
         ]
         # Sort items descending by date
         filtered_items.sort(key=get_pub_sort_key, reverse=True)
@@ -404,6 +406,7 @@ def generate_sitemap():
     add_url(f"{BASE}/members/", changefreq="monthly", priority="0.8")
     add_url(f"{BASE}/publications/", changefreq="monthly", priority="0.8")
     add_url(f"{BASE}/news/", changefreq="weekly", priority="0.8")
+    add_url(f"{BASE}/group-life/", changefreq="monthly", priority="0.6")
 
     # Member pages (deduplicated — some members appear in multiple groups)
     seen_member_links = set()

--- a/contents/structures/pages.json
+++ b/contents/structures/pages.json
@@ -36,7 +36,7 @@
             {
                 "id": "group-life",
                 "title": "Group Life",
-                "link": "/#group-life",
+                "link": "/group-life",
                 "icon": "/assets/sprite.svg#svg-picture"
             },
             {
@@ -73,5 +73,12 @@
         "description": "Peer-reviewed publications from E3 Center, NTU, on sustainable energy transition, transportation electrification, and climate policy.",
         "subpageTitle": "Publications",
         "template": "pages/publications"
+    },
+    "group-life-page": {
+        "path": "group-life",
+        "title": "Group Life | E3 Center",
+        "description": "Photos from the E3 Center group at National Taiwan University — research life, events, gatherings, conferences, and milestones.",
+        "subpageTitle": "Group Life",
+        "template": "pages/group-life"
     }
 }

--- a/contents/structures/publications.json
+++ b/contents/structures/publications.json
@@ -1,12 +1,27 @@
 [
     {
+        "sectionTitle": "Books",
+        "showInHome": 0,
+        "items": [
+            {
+                "type": "book",
+                "title": "能源新未來：永續策略與實踐",
+                "authors": "I-Yun Lisa Hsieh, Chon Man Tam",
+                "publisher": "Yi Pin Publishing (一品出版社)",
+                "year": "'25",
+                "isbn": "9786269995202",
+                "E3": true
+            }
+        ]
+    },
+    {
         "sectionTitle": "Recent Publications",
         "showInHome": 5,
         "items": [
             {
                 "citationId": "tUbPb-QAAAAJ:_kc_bZDykSQC",
                 "title": "Assessing Power Sector Carbon Emission Intensity in Taiwan: Status Quo and Net-zero Future Perspectives",
-                "link": "https://km.twenergy.org.tw/Publication/thesis_more?id=325",
+                "link": "https://ea01.moeaea.gov.tw/publication/journal/thesis/37/301",
                 "journal": "Journal of Taiwan Energy (臺灣能源期刊)",
                 "volume": "9",
                 "year": "'22",
@@ -18,7 +33,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:4TOpqqG69KYC",
                 "title": "Sankey-diagram-based Insights Into Taiwan’s Energy Flow: Status Quo and Net-zero Future",
-                "link": "https://km.twenergy.org.tw/Publication/thesis_more?id=330",
+                "link": "https://ea01.moeaea.gov.tw/publication/journal/thesis/37/306",
                 "journal": "Journal of Taiwan Energy (臺灣能源期刊)",
                 "volume": "9",
                 "year": "'22",
@@ -209,7 +224,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:9ZlFYXVOiuMC",
                 "title": "Comparison and Strategic Outlook of International Solid Recovered Fuel Standards",
-                "link": "https://km.twenergy.org.tw/publication/thesis_more?id=384",
+                "link": "https://ea01.moeaea.gov.tw/publication/journal/thesis/45/353",
                 "journal": "Journal of Taiwan Energy (臺灣能源期刊)",
                 "volume": "11",
                 "year": "'24",
@@ -221,7 +236,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:QIV2ME_5wuYC",
                 "title": "Green Transformation of Bus Shelters: Implementation and Benefits of Solar Photovoltaic and Energy Storage Technologies",
-                "link": "https://km.twenergy.org.tw/publication/thesis_more?id=386",
+                "link": "https://ea01.moeaea.gov.tw/publication/journal/thesis/45/355",
                 "journal": "Journal of Taiwan Energy (臺灣能源期刊)",
                 "volume": "11",
                 "year": "'24",
@@ -466,6 +481,15 @@
                 "status": "submitted",
                 "year": "'26",
                 "month": "Mar.",
+                "E3": true
+            },
+            {
+                "title": "淨零轉型下機車電動化的減碳效益：臺灣與中國之比較研究",
+                "journal": "Transportation Planning Journal (運輸計畫季刊)",
+                "authors": "Pei-Tzu Chen, Wei-Hsuan Chen, I-Yun Lisa Hsieh",
+                "status": "under-review",
+                "year": "'26",
+                "month": "May.",
                 "E3": true
             }
         ]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -882,25 +882,32 @@
 
 }
 
-/* members / news / publications — section-title "All …" button */
-#members .section-title,
-#news .section-title,
-#publications .section-title {
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 2rem;
+/* members / news / publications — bottom-of-section "View all" CTA */
+.section-cta {
+    display: flex;
+    justify-content: center;
+    margin-block-start: 3rem;
+}
 
-    & .more {
-        --_adjusted-font-size: 1.25rem;
-        --_adjusted-padding: 0.5em 1em;
-        margin: 0 0 0.5rem 0;
-        flex-shrink: 0;
+.section-cta-btn {
+    --_adjusted-font-size: 1.125rem;
+    --_adjusted-padding: 0.875em 2em;
 
-        & svg {
-            height: 1em;
-            width: auto;
-            translate: 0 0;
-        }
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    cursor: pointer;
+    transition: background-color 200ms ease-out, color 200ms ease-out;
+
+    & svg {
+        height: 1em;
+        width: auto;
+        transition: translate 200ms ease-out;
+    }
+
+    &:hover svg,
+    &:focus-visible svg {
+        translate: 0.25rem 0;
     }
 }
 
@@ -2539,16 +2546,13 @@
         justify-content: center;
     }
 
-    /* News & publications — section-title "All" button on its own line so
-       it doesn't compete with the headline for horizontal space. */
-    #members .section-title,
-    #news .section-title,
-    #publications .section-title {
-        flex-wrap: wrap;
-        gap: 0.75rem;
+    /* CTA scales down slightly on tablet/phone */
+    .section-cta {
+        margin-block-start: 2rem;
+    }
 
-        & .more {
-            --_adjusted-font-size: 1rem;
-        }
+    .section-cta-btn {
+        --_adjusted-font-size: 1rem;
+        --_adjusted-padding: 0.75em 1.5em;
     }
 }

--- a/static/css/subpage.css
+++ b/static/css/subpage.css
@@ -142,7 +142,8 @@
    Padding-inline reuses the homepage --gutter-x token for consistency. */
 .members-subpage,
 .news-subpage,
-.publications-subpage {
+.publications-subpage,
+.group-life-subpage {
     width: min(100%, 80rem);
     margin-inline: auto;
     padding-block: 4rem 8rem;
@@ -759,7 +760,8 @@
     /* Page-level padding — match member individual subpage's main(). */
     .members-subpage,
     .news-subpage,
-    .publications-subpage {
+    .publications-subpage,
+    .group-life-subpage {
         padding-block: 1.5rem 4rem;
     }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -58,8 +58,8 @@
 
     <!-- css -->
     <link rel="stylesheet" href="/css/general.css?v=13">
-    <link rel="stylesheet" href="/css/style.css?v=10">
-    <link rel="stylesheet" href="/css/subpage.css?v=14">
+    <link rel="stylesheet" href="/css/style.css?v=11">
+    <link rel="stylesheet" href="/css/subpage.css?v=15">
 
     <!-- js -->
     <script defer src="/js/general.js"></script>

--- a/templates/home/group-life.html
+++ b/templates/home/group-life.html
@@ -1,7 +1,6 @@
 <section id="group-life">
     <div class="section-title">
-        <h2>Group Life</h2>
-
+        <h2><a class="section-title-link" href="/group-life/">Group Life</a></h2>
     </div>
 
     {% for group_life in structures['group-life'] %}
@@ -33,8 +32,8 @@
                     {% set imgPathFront = item['imgPath'].split('.')[0] %}
                     <div class="glf-slider-img skewed-block" b-role="block" style="background-image: url({{ imgPathFront }}-20w.webp);">
                         <img
-                            loading="lazy" 
-                            src="{{ item['imgPath'] }}" 
+                            loading="lazy"
+                            src="{{ item['imgPath'] }}"
                             srcset="
                                 {{ imgPathFront }}-200w.webp 200w,
                                 {{ imgPathFront }}-400w.webp 400w,
@@ -58,55 +57,12 @@
             </div>
         </div>
     </section>
+    {% endfor %}
 
-    <h3>{{ group_life['sectionTitle'] }}</h3>
-    {% if group_life['filter'] %}
-    <div class="filter" where="{{ group_life['filterId'] }}">
-        <span class="filter-title">{{ group_life['filterTitle'] }}</span>
-        {% set ns = namespace(filterItems=[]) %}
-        {% for item in group_life['items'] %}
-            {% if item['year'] not in ns.filterItems %}
-                {% set ns.filterItems = ns.filterItems + [item['year']] %}
-            {% endif %}
-        {% endfor %}
-        {% for filterItem in ns.filterItems[::-1] %}
-        <label class="filter-block skewed-block" b-role="btn" b-hoverable>
-            <input class="filter-checkbox" type="checkbox" where="{{ group_life['filterId'] }}" value="{{ filterItem }}"{% if loop.index <= group_life['filterDefaultCheck'] %} checked{% endif %}/>
-            <div class="filter-label">
-                <svg><use href="/assets/sprite.svg#svg-check"></use></svg>
-                {{ filterItem }}
-            </div>
-        </label>
-        {% endfor %}
+    <div class="section-cta">
+        <a class="section-cta-btn skewed-block" href="/group-life/" b-role="btn" b-hoverable>
+            <span>View all photos</span>
+            <svg><use href="/assets/sprite.svg#svg-arrow-right"></use></svg>
+        </a>
     </div>
-    {% endif %}
-
-    <section class="glf-section" which="all">
-        {% for item in group_life['items'][::-1] %}
-        <div class="glf-block filter-content" where="{{ group_life['filterId'] }}" data-value="{{item['year']}}">
-            {% set imgPathFront = item['imgPath'].split('.')[0] %}
-            <div class="glf-img skewed-block zoomable" b-role="block" b-hoverable style="background-image: url({{ imgPathFront }}-20w.webp);">
-                <img 
-                    loading="lazy"
-                    src="{{ item['imgPath'] }}" 
-                    srcset="
-                        {{ imgPathFront }}-200w.webp 200w,
-                        {{ imgPathFront }}-400w.webp 400w,
-                        {{ imgPathFront }}-600w.webp 600w,
-                        {{ imgPathFront }}-800w.webp 800w,
-                        {{ imgPathFront }}-1200w.webp 1200w,
-                        {{ imgPathFront }}-1600w.webp 1600w,
-                        {{ imgPathFront }}-2000w.webp 2000w
-                    "
-                    sizes="20rem"
-                    alt="{{ item['month'] }} {{ item['year'] }}. {{ item['description'] }}"
-                />
-            </div>
-            <span class="glf-img-text">
-                {{ item['month'] }} {{ item['year'] }}
-            </span>
-        </div>
-        {% endfor %}
-    </section>
-{% endfor %}
 </section>

--- a/templates/home/members.html
+++ b/templates/home/members.html
@@ -1,12 +1,6 @@
 <section id="members">
     <div class="section-title">
         <h2><a class="section-title-link" href="/members/">Members</a></h2>
-        {% if isHomePage %}
-        <a class="more skewed-block" href="/members/" b-role="btn" b-hoverable>
-            <div>All members</div>
-            <svg><use href="/assets/sprite.svg#svg-arrow-right"></use></svg>
-        </a>
-        {% endif %}
     </div>
 
     {% for members in structures['members'] %}
@@ -152,4 +146,13 @@
     {% endif %}
     {% endif %}
     {% endfor %}
+
+    {% if isHomePage %}
+    <div class="section-cta">
+        <a class="section-cta-btn skewed-block" href="/members/" b-role="btn" b-hoverable>
+            <span>View all members</span>
+            <svg><use href="/assets/sprite.svg#svg-arrow-right"></use></svg>
+        </a>
+    </div>
+    {% endif %}
 </section>

--- a/templates/home/news.html
+++ b/templates/home/news.html
@@ -1,10 +1,6 @@
 <section id="news">
     <div class="section-title">
         <h2><a class="section-title-link" href="/news/">News</a></h2>
-        <a class="more skewed-block" href="/news/" b-role="btn" b-hoverable>
-            <div>All News</div>
-            <svg><use href="/assets/sprite.svg#svg-arrow-right"></use></svg>
-        </a>
     </div>
 
     {% for news in structures['news'] %}
@@ -48,4 +44,11 @@
     </div>
     {% endfor %}
     {% endfor %}
+
+    <div class="section-cta">
+        <a class="section-cta-btn skewed-block" href="/news/" b-role="btn" b-hoverable>
+            <span>See all news</span>
+            <svg><use href="/assets/sprite.svg#svg-arrow-right"></use></svg>
+        </a>
+    </div>
 </section>

--- a/templates/home/publications.html
+++ b/templates/home/publications.html
@@ -1,14 +1,11 @@
 <section id="publications">
     <div class="section-title">
         <h2><a class="section-title-link" href="/publications/">Publications</a></h2>
-        <a class="more skewed-block" href="/publications/" b-role="btn" b-hoverable>
-            <div>All Publications</div>
-            <svg><use href="/assets/sprite.svg#svg-arrow-right"></use></svg>
-        </a>
     </div>
 
     {% for publication in structures['home_publications'] %}
     {% set home_items = publication['items'][:publication['showInHome']] %}
+    {% if home_items %}
     <div class="publi-group" id="home-pub-{{ loop.index }}">
         <h3 class="publi-group-title">Recent Publications</h3>
         <div class="news-rows">
@@ -54,5 +51,13 @@
             {% endfor %}
         </div>
     </div>
+    {% endif %}
     {% endfor %}
+
+    <div class="section-cta">
+        <a class="section-cta-btn skewed-block" href="/publications/" b-role="btn" b-hoverable>
+            <span>Browse all publications</span>
+            <svg><use href="/assets/sprite.svg#svg-arrow-right"></use></svg>
+        </a>
+    </div>
 </section>

--- a/templates/pages/group-life.html
+++ b/templates/pages/group-life.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+{% set description = 'Photos from the E3 Center group at National Taiwan University — research life, events, gatherings, conferences, and milestones. Directed by Prof. I-Yun Lisa Hsieh (謝依芸).' %}
+{% set keywords = 'E3 Center group life, E3 group photos, NTU sustainable energy group, lab life, group gatherings, conferences, events, I-Yun Lisa Hsieh, 謝依芸, 台大, 國立臺灣大學' %}
+{% set canonicalLink = 'https://e3center.caece.net/group-life/' %}
+{% block jsonld %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Group Life | E3 Center",
+  "url": "https://e3center.caece.net/group-life/",
+  "isPartOf": { "@id": "https://e3center.caece.net/#organization" }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://e3center.caece.net/" },
+    { "@type": "ListItem", "position": 2, "name": "Group Life" }
+  ]
+}
+</script>
+{% endblock %}
+{% block content %}
+<section id="group-life" class="group-life-subpage">
+
+    {% for group_life in structures['group-life'] %}
+    {% if group_life['filter'] %}
+    <div class="filter" where="{{ group_life['filterId'] }}">
+        <span class="filter-title">{{ group_life['filterTitle'] }}</span>
+        {% set ns = namespace(filterItems=[]) %}
+        {% for item in group_life['items'] %}
+            {% if item['year'] not in ns.filterItems %}
+                {% set ns.filterItems = ns.filterItems + [item['year']] %}
+            {% endif %}
+        {% endfor %}
+        {% for filterItem in ns.filterItems[::-1] %}
+        <label class="filter-block skewed-block" b-role="btn" b-hoverable>
+            <input class="filter-checkbox" type="checkbox" where="{{ group_life['filterId'] }}" value="{{ filterItem }}"{% if loop.index <= group_life['filterDefaultCheck'] %} checked{% endif %}/>
+            <div class="filter-label">
+                <svg><use href="/assets/sprite.svg#svg-check"></use></svg>
+                {{ filterItem }}
+            </div>
+        </label>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    <section class="glf-section" which="all">
+        {% for item in group_life['items'][::-1] %}
+        <div class="glf-block filter-content" where="{{ group_life['filterId'] }}" data-value="{{item['year']}}">
+            {% set imgPathFront = item['imgPath'].split('.')[0] %}
+            <div class="glf-img skewed-block zoomable" b-role="block" b-hoverable style="background-image: url({{ imgPathFront }}-20w.webp);">
+                <img
+                    loading="lazy"
+                    src="{{ item['imgPath'] }}"
+                    srcset="
+                        {{ imgPathFront }}-200w.webp 200w,
+                        {{ imgPathFront }}-400w.webp 400w,
+                        {{ imgPathFront }}-600w.webp 600w,
+                        {{ imgPathFront }}-800w.webp 800w,
+                        {{ imgPathFront }}-1200w.webp 1200w,
+                        {{ imgPathFront }}-1600w.webp 1600w,
+                        {{ imgPathFront }}-2000w.webp 2000w
+                    "
+                    sizes="20rem"
+                    alt="{{ item['month'] }} {{ item['year'] }}. {{ item['description'] }}"
+                />
+            </div>
+            <span class="glf-img-text">
+                {{ item['month'] }} {{ item['year'] }}
+            </span>
+        </div>
+        {% endfor %}
+    </section>
+    {% endfor %}
+
+</section>
+{% endblock %}

--- a/templates/pages/publications.html
+++ b/templates/pages/publications.html
@@ -61,6 +61,45 @@
         {% endfor %}
     {% endfor %}
 
+    {# ── Macro: render a single book row ────────────────────────────────────── #}
+    {% macro pub_book_row(item) %}
+    {% if item.get('link') %}
+    <a class="news-row news-row--link" href="{{ item['link'] }}" target="_blank" rel="noopener">
+    {% else %}
+    <div class="news-row">
+    {% endif %}
+
+        <div class="news-row-date">
+            <span class="news-row-mm">Book</span>
+            <span class="news-row-yy">20{{ item['year'][1:] }}</span>
+        </div>
+
+        <div class="news-row-body">
+            <p class="news-row-title">{{ item['title'] }}</p>
+            {% if item.get('authors') %}
+            <span class="publi-row-authors">{{ item['authors'] }}</span>
+            {% endif %}
+            {% if item.get('publisher') %}
+            <span class="publi-row-journal">
+                {{- item['publisher'] -}}
+                {%- if item.get('isbn') %}. ISBN {{ item['isbn'] }}{%- endif -%}
+            </span>
+            {% endif %}
+        </div>
+
+        {% if item.get('link') %}
+        <span class="news-row-arrow" aria-hidden="true">
+            <svg><use href="/assets/sprite.svg#svg-arrow-top-right"></use></svg>
+        </span>
+        {% endif %}
+
+    {% if item.get('link') %}
+    </a>
+    {% else %}
+    </div>
+    {% endif %}
+    {% endmacro %}
+
     {# ── Macro: render a single publication row ─────────────────────────────── #}
     {% macro pub_row(item) %}
     {% set status = item.get('status', 'published') %}
@@ -144,13 +183,15 @@
     {% endif %}
     {% endmacro %}
 
+    {% set book_items = all_items | selectattr('type', 'equalto', 'book') | list %}
+
     {# ── Working Papers: submitted first, then under-review ─────────────────── #}
-    {% set submitted_items    = all_items | selectattr('status', 'equalto', 'submitted')    | list %}
-    {% set under_review_items = all_items | selectattr('status', 'equalto', 'under-review') | list %}
+    {% set submitted_items    = all_items | rejectattr('type', 'equalto', 'book') | selectattr('status', 'equalto', 'submitted')    | list %}
+    {% set under_review_items = all_items | rejectattr('type', 'equalto', 'book') | selectattr('status', 'equalto', 'under-review') | list %}
     {{ pub_group('Working Papers', submitted_items + under_review_items, 'pub-working') }}
 
     {# ── All Publications ────────────────────────────────────────────────── #}
-    {% set published = all_items | selectattr('status', 'equalto', 'published') | list %}
+    {% set published = all_items | rejectattr('type', 'equalto', 'book') | selectattr('status', 'equalto', 'published') | list %}
     {{ pub_group('All Publications', published, 'pub-recent') }}
 
     <div class="publi-scholar-cta">
@@ -164,6 +205,18 @@
             <p>Prof. Lisa's Google Scholar</p>
         </a>
     </div>
+
+    {# ── Books (rendered last, after Google Scholar CTA) ───────────────────── #}
+    {% if book_items %}
+    <div class="publi-group" id="pub-books">
+        <h3 class="publi-group-title">Books</h3>
+        <div class="news-rows">
+            {% for item in book_items %}
+            {{ pub_book_row(item) }}
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
 
 </section>
 


### PR DESCRIPTION
## Summary
- Add new under-review paper (Chinese title, Transportation Planning Journal) and new **Books** section to publications, with Hsieh & Tan (2025) 《能源新未來：永續策略與實踐》 rendered below the Google Scholar CTA
- Move the full Group Life photo grid + year filter to a dedicated `/group-life/` subpage; home now shows the slider plus a "View all photos" CTA only
- Redesign the "All X" links across Members / News / Publications / Group Life: removed the small top-right pill and added a prominent centered button below each section's content for better discoverability (arrow slides right on hover)

## Test plan
- [ ] `/publications/` — Books group renders below Google Scholar CTA; accepted Transportation Planning Journal paper appears under Working Papers with "Under Review" badge
- [ ] `/` — Group Life section shows only slider + "View all photos" CTA (no full grid)
- [ ] `/group-life/` — subpage renders breadcrumb + year filter + full photo grid
- [ ] Menu: Group Life link navigates to `/group-life/`
- [ ] All four "View all" CTAs render centered below their sections; arrow translates on hover/focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)