### PR TITLE
Add TUKUC and NSTC-NWO bilateral grants to Projects

### DIFF
--- a/contents/projects/projects.json
+++ b/contents/projects/projects.json
@@ -47,6 +47,17 @@
                 "status": "執行中"
             },
             {
+                "titleZh": "永續能源與交通的系統性解決方案",
+                "titleEn": "Systematic Solutions for Sustainable Energy and Mobility System",
+                "grantNumber": "114-2927-I-002-528",
+                "role": "主持人",
+                "startDate": "2025-07-01",
+                "endDate": "2026-06-30",
+                "fundingAgency": "國科會（臺荷 NSTC-NWO 雙邊交流）",
+                "fundingAgencyEn": "National Science and Technology Council (NSTC) – Taiwan-Netherlands (NSTC-NWO) Bilateral Program",
+                "status": "執行中"
+            },
+            {
                 "titleZh": "智慧型電池換電系統最佳化：運用人工智慧推動能源部門耦合達成淨零能耗建築",
                 "titleEn": "Smart Battery Swap System Optimization: Advancing Sector Coupling with Artificial Intelligence for Nearly Zero-Energy Buildings",
                 "grantNumber": "113-2621-M-002-006-",
@@ -252,6 +263,16 @@
                 "endDate": "2026-10-05",
                 "fundingAgency": "財團法人金屬工業研究發展中心",
                 "fundingAgencyEn": "Metal Industries Research & Development Centre (MIRDC)",
+                "status": "執行中"
+            },
+            {
+                "titleZh": "人工智慧與人類協同推動淨零物流轉型之臺英合作研究架構",
+                "titleEn": "AI–Human Coordination for Net-Zero Logistics Transition: A UK–Taiwan Collaborative Framework",
+                "role": "主持人",
+                "startDate": "2026-04-15",
+                "endDate": "2026-12-31",
+                "fundingAgency": "教育部臺英大學聯盟 (TUKUC)",
+                "fundingAgencyEn": "Ministry of Education – Taiwan-UK University Consortium (TUKUC)",
                 "status": "執行中"
             }
         ]


### PR DESCRIPTION
## Summary
Adds two of Prof. Hsieh's awarded research projects to `contents/projects/projects.json`.

| Section | Project | Period | Status |
|---------|---------|--------|--------|
| 臺灣國科會 (NSTC) | Systematic Solutions for Sustainable Energy and Mobility System — `114-2927-I-002-528`, NSTC–NWO Taiwan–Netherlands bilateral seminar (U. Groningen) | 2025-07-01 → 2026-06-30 | 執行中 |
| 其他計畫 (Other) | AI–Human Coordination for Net-Zero Logistics Transition — TUKUC / MOE Taiwan-UK University Consortium (Newcastle University) | 2026-04-15 → 2026-12-31 | 執行中 |

Both entries keep uniform keys within their section (NSTC entries carry `grantNumber`; Other entries do not).

## Notes / judgment calls
- **NSTC start date:** the 核定函 (approval letter) states 114/07/01 = **2025-07-01**; the final report's header reads 2024年7月1日, which appears to be a typo for a 114年度 award. Used the approval letter.
- **NSTC status:** the seminar ran Mar 2026 and the 期末報告 is filed, but the official period ends 2026-06-30, so marked **執行中** (consistent with how the dataset treats not-yet-ended projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)