### PR TITLE
feat(publications): per-publication detail pages

### DIFF
--- a/build.py
+++ b/build.py
@@ -65,6 +65,97 @@ def get_pub_sort_key(item):
             
     return (year, month_num)
 
+
+# ── Publication detail-page helpers: slug + derived BibTeX ────────────────────
+# A publication earns a detail page once it has an `abstract`. Its URL slug and
+# its BibTeX are derived from the structured fields so there is a single source
+# of truth (no duplicated blob to drift). An explicit `slug` or `bibtex` field,
+# if present, overrides the derived value.
+
+_BIBTEX_STOPWORDS = {"a", "an", "the", "on", "of", "in", "for", "and", "to", "with"}
+_MONTHS3 = {"jan", "feb", "mar", "apr", "may", "jun",
+            "jul", "aug", "sep", "oct", "nov", "dec"}
+
+
+def pub_year4(item):
+    """4-digit year string from a publication's `year` (handles the "'YY" form)."""
+    y = str(item.get('year', '') or '')
+    return ('20' + y[1:]) if y.startswith("'") else y
+
+
+def slugify_title(text, max_words=7):
+    """Lowercase, hyphenated slug keeping the first `max_words` significant words."""
+    words = re.sub(r'[^a-z0-9\s-]', '', text.lower()).split()
+    return '-'.join(words[:max_words]).strip('-')
+
+
+def pub_slug(item):
+    """Explicit `slug` wins; otherwise derive `<year>-<title-slug>`."""
+    if item.get('slug'):
+        return item['slug']
+    return f"{pub_year4(item) or 'na'}-{slugify_title(item.get('title', ''))}".strip('-')
+
+
+def _bibtex_authors(item):
+    """'Last, First and Last, First'. Prefers structured authorList; falls back
+    to the comma-separated `authors` string."""
+    if item.get('authorList'):
+        names = [a.get('name', '') for a in item['authorList'] if a.get('name')]
+    else:
+        names = [n.strip() for n in (item.get('authors') or '').split(',') if n.strip()]
+    out = []
+    for n in names:
+        parts = n.split()
+        out.append(f"{parts[-1]}, {' '.join(parts[:-1])}" if len(parts) >= 2 else n)
+    return ' and '.join(out)
+
+
+def _bibtex_key(item):
+    """Scholar-style key: <firstAuthorLastname><year><firstSignificantTitleWord>."""
+    if item.get('authorList') and item['authorList']:
+        first = item['authorList'][0].get('name', '')
+    else:
+        first = (item.get('authors') or '').split(',')[0]
+    parts = first.split()
+    last = re.sub(r'[^a-z0-9]', '', parts[-1].lower()) if parts else 'anon'
+    word = ''
+    for w in re.sub(r'[^a-z0-9\s-]', '', item.get('title', '').lower()).split():
+        if w not in _BIBTEX_STOPWORDS:
+            word = w.split('-')[0]
+            break
+    return f"{last}{pub_year4(item)}{word}"
+
+
+def generate_bibtex(item):
+    """Assemble a BibTeX entry from structured fields. An explicit `bibtex` field
+    overrides the derived output verbatim."""
+    if item.get('bibtex'):
+        return item['bibtex']
+    fields = [
+        ('title', item.get('title')),
+        ('author', _bibtex_authors(item)),
+        ('journal', (item.get('journal') or '').replace('&', r'\&')),
+        ('volume', item.get('volume')),
+        ('number', item.get('issue')),
+        ('pages', item.get('articleNo') or item.get('pages')),
+        ('year', pub_year4(item)),
+        ('month', (item.get('month') or '').strip('.').lower()[:3]),
+        ('doi', item.get('doi')),
+    ]
+    rendered = []
+    for k, v in fields:
+        if not v:
+            continue
+        if k == 'month':
+            if v in _MONTHS3:           # bare macro, no braces (per house style)
+                rendered.append(f"  month={v}")
+        else:
+            rendered.append(f"  {k}={{{v}}}")
+    if not rendered:
+        return ''
+    return "@article{" + _bibtex_key(item) + ",\n" + ',\n'.join(rendered) + "\n}"
+
+
 def news_slug_from_pagelink(page_link):
     """Extract the news slug from a pageLink like '/news/2026-foo/' -> '2026-foo'."""
     return page_link.rstrip('/').rsplit('/', 1)[-1] if page_link else ''
@@ -118,6 +209,18 @@ if 'publications' in structures:
         new_section['items'] = filtered_items
         home_publications.append(new_section)
     structures['home_publications'] = home_publications
+
+# A publication earns a detail page once it has an `abstract`. Annotate those
+# with their slug + pageLink (derived if not set explicitly) so the listing
+# template links each such row to /publications/<slug>/. Mutates the shared
+# structures dict before any template renders. Publications without an abstract
+# are left untouched — they keep the original whole-row publisher link.
+if 'publications' in structures:
+    for _section in structures['publications']:
+        for _item in _section.get('items', []):
+            if _item.get('abstract'):
+                _item['slug'] = pub_slug(_item)
+                _item['pageLink'] = f"/publications/{_item['slug']}/"
 
 # Load page-body markdown for each subpage that has one.
 articles = {}
@@ -386,6 +489,47 @@ def render_news_pages():
     print("News item pages rendered successfully!")
 
 
+# Function to render individual publication detail pages from publications.json.
+# A page is generated for every entry with an `abstract` (detail pages are
+# opt-in). The slug and BibTeX are derived from the structured fields. Authors
+# in `authorList` whose webId matches an E3 member are linked to that member's
+# page by the template (member_ids gates the link).
+def render_publication_pages():
+    template = env.get_template('pages/publications/publication-item.html')
+    member_ids = set(members_by_id.keys())
+
+    count = 0
+    for section in structures.get('publications', []):
+        for item in section.get('items', []):
+            if not item.get('abstract'):
+                continue
+
+            pub = dict(item)
+            slug = pub.get('slug') or pub_slug(pub)
+            pub['slug'] = slug
+            pub['pageLink'] = pub.get('pageLink') or f"/publications/{slug}/"
+            # BibTeX is derived from the structured fields (single source of
+            # truth); an explicit `bibtex` field, if present, overrides it.
+            pub['bibtex'] = generate_bibtex(pub)
+
+            output = template.render(
+                pub=pub,
+                member_ids=member_ids,
+                pages=pages,
+                structures=structures,
+                year=datetime.now().year,
+            )
+
+            page_dir = os.path.join(output_dir, pub['pageLink'].lstrip('/'))
+            os.makedirs(page_dir, exist_ok=True)
+            with open(os.path.join(page_dir, 'index.html'), 'w', encoding='utf-8') as f:
+                f.write(output)
+            count += 1
+            print(f"Publication page generated: {pub['pageLink']}")
+
+    print(f"Publication detail pages rendered successfully! ({count})")
+
+
 # Function to generate sitemap.xml with all indexable pages
 def generate_sitemap():
     from xml.etree.ElementTree import Element, SubElement, ElementTree, indent
@@ -480,6 +624,15 @@ def generate_sitemap():
                         lastmod=latest_mtime(f"contents/news/articles/{slug}.md",
                                              f"contents/news/images/{slug}",
                                              "contents/news/news.json"))
+
+    # Publication detail pages — one per entry with an abstract. lastmod tracks
+    # the publications data file (the page is rendered entirely from it).
+    for section in structures.get('publications', []):
+        for item in section.get('items', []):
+            if item.get('abstract'):
+                add_url(f"{BASE}/publications/{item.get('slug') or pub_slug(item)}/",
+                        changefreq="yearly", priority="0.6",
+                        lastmod=latest_mtime("contents/publications/publications.json"))
 
     tree = ElementTree(urlset)
     indent(tree, space="  ")
@@ -704,6 +857,8 @@ if __name__ == "__main__":
     render_member_pages()
     print("Rendering news item pages...")
     render_news_pages()
+    print("Rendering publication detail pages...")
+    render_publication_pages()
     print("Copying static assets...")
     copy_static()
     print("Copying videos...")

--- a/contents/publications/publications.json
+++ b/contents/publications/publications.json
@@ -324,7 +324,28 @@
                 "month": "Jan.",
                 "authors": "Jun-Wei Ding, I-Yun Lisa Hsieh",
                 "E3": true,
-                "status": "published"
+                "status": "published",
+                "slug": "2026-super-resolution-wind-mapping",
+                "volume": "7",
+                "articleNo": "51",
+                "doi": "10.1038/s43247-025-03072-9",
+                "tags": [
+                    "Renewable Energy",
+                    "AI & Machine Learning"
+                ],
+                "authorList": [
+                    {
+                        "name": "Jun-Wei Ding",
+                        "webId": "junweiding"
+                    },
+                    {
+                        "name": "I-Yun Lisa Hsieh",
+                        "webId": "iyunlisahsieh"
+                    }
+                ],
+                "abstract": "Accurate wind information is crucial for expanding renewable energy, yet achieving high spatial resolution and accuracy simultaneously remains challenging. This challenge is intensified in regions with sparse surface observations, where uneven station coverage can bias model assessment. Here we present a deep learning framework that reconstructs high-resolution wind fields by combining frequency-based filtering with a generative model designed to enhance local detail while preserving large-scale structure. We also introduce a point-to-area Monte Carlo evaluation strategy that accounts for spatial heterogeneity across measurement sites, enabling a reliable assessment of model performance. Applied to regional wind reconstruction, the framework enhances wind-speed estimation and provides a clearer representation of fine-scale variability, particularly under conditions associated with high wind-energy production. The approach performs consistently across multiple spatial domains and temporal aggregation levels, supporting its potential for scalable and location-sensitive wind-energy planning in settings where observational data are limited.",
+                "shortTitle": "Super-Resolution Wind Mapping with Deep Learning",
+                "issue": "1"
             },
             {
                 "citationId": "tUbPb-QAAAAJ:digitalization-lca-pod",

--- a/static/css/publication-item.css
+++ b/static/css/publication-item.css
@@ -1,0 +1,313 @@
+/* ── Publication Item (detail) Page ──────────────────────────────────────────
+   Standalone page generated per publication (see build.py render_publication_pages).
+   Mirrors the news-item page conventions: subpage header + breadcrumb, a single
+   centred reading column, footer. Anchored to the shared tokens in general.css. */
+
+/* Same content width as the other subpages (news-item, members): 80rem. */
+.pub-item-main {
+    width: min(100%, 80rem);
+    margin-inline: auto;
+    padding: 3rem var(--gutter-x) 8rem;
+}
+
+/* ── Header block ─────────────────────────────────────────────────────────── */
+
+.pub-item-tags {
+    list-style: none;
+    margin: 0 0 1.25rem;
+    padding: 0;
+
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.pub-tag-chip {
+    font-size: var(--fs-caption);
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    line-height: 1.4;
+    padding: 0.25rem 0.75rem;
+    border-radius: 2rem;
+    color: var(--main-color-2);
+    background: color-mix(in srgb, var(--main-color-2) 12%, transparent);
+}
+
+.pub-item-title {
+    font-size: clamp(1.625rem, 3.2vw, 2.125rem);
+    font-weight: var(--fw-h1);
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+    color: var(--main-color);
+    margin: 0 0 1.25rem;
+}
+
+.pub-item-authors {
+    font-size: var(--fs-body-l);
+    line-height: 1.5;
+    color: var(--main-color);
+    margin: 0 0 0.5rem;
+}
+
+/* Animated underline on author links — matches the about-section link recipe. */
+.pub-author-link {
+    color: color-mix(in srgb, var(--main-color) 55%, var(--main-color-2) 45%);
+    font-weight: 600;
+    text-decoration: none;
+    background-image: linear-gradient(currentColor, currentColor);
+    background-position: 0 100%;
+    background-repeat: no-repeat;
+    background-size: 0% 1px;
+    padding-bottom: 0.06em;
+    transition:
+        background-size 280ms cubic-bezier(0.16, 1, 0.3, 1),
+        color 200ms ease-out;
+
+    &:hover, &:focus-visible {
+        background-size: 100% 1px;
+        color: var(--main-color-2);
+    }
+
+    &:focus-visible {
+        outline: 2px solid currentColor;
+        outline-offset: 3px;
+        border-radius: 2px;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        transition: none;
+    }
+}
+
+/* ── Two-column body: reading content + metadata card ─────────────────────── */
+
+.pub-item-layout {
+    margin-block-start: 2.5rem;
+    padding-block-start: 2.5rem;
+    border-block-start: 0.0625rem solid color-mix(in srgb, var(--main-color) 14%, transparent);
+
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 20rem;
+    gap: 2.5rem 3.5rem;
+    align-items: start;
+}
+
+/* min-width:0 lets the BibTeX <pre> scroll instead of stretching the column. */
+.pub-item-content {
+    min-width: 0;
+}
+
+/* Metadata card — venue + publisher action + DOI. Sticks below the sticky
+   subpage header on tall content. */
+.pub-meta-card {
+    position: sticky;
+    top: 7rem;
+
+    border: 0.0625rem solid color-mix(in srgb, var(--main-color) 14%, transparent);
+    border-radius: 0.625rem;
+    background: color-mix(in srgb, var(--main-color) 4%, transparent);
+    padding: 1.5rem;
+
+    display: flex;
+    flex-direction: column;
+}
+
+.pub-meta-label {
+    font-size: var(--fs-eyebrow);
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--main-color) 45%, transparent);
+    margin: 0 0 0.4rem;
+}
+
+.pub-meta-journal {
+    font-size: 1.0625rem;
+    font-style: italic;
+    line-height: 1.4;
+    color: var(--main-color);
+    margin: 0;
+}
+
+.pub-meta-detail {
+    font-size: 0.875rem;
+    line-height: 1.4;
+    color: color-mix(in srgb, var(--main-color) 65%, transparent);
+    margin: 0.3rem 0 0;
+}
+
+/* "View on publisher" — re-uses the skewed-block btn theme; full-width in card. */
+.pub-action-btn {
+    --_adjusted-font-size: 0.9375rem;
+    --_adjusted-padding: 0.55em 1em;
+    width: 100%;
+    margin-block-start: 1.25rem;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+
+    & svg {
+        height: 0.75em;
+        width: 0.75em;
+    }
+}
+
+/* DOI shown as a plain, citable identifier (the button already resolves to it,
+   so this is selectable text, not a second link). */
+.pub-item-doi {
+    margin: 1.25rem 0 0;
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+
+    font-size: var(--fs-eyebrow);
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--main-color) 45%, transparent);
+
+    & span {
+        font-family: "SFMono-Regular", "SF Mono", "Menlo", "Consolas",
+                     "Liberation Mono", monospace;
+        font-size: 0.75rem;
+        font-weight: 400;
+        letter-spacing: 0;
+        text-transform: none;
+        color: color-mix(in srgb, var(--main-color) 78%, transparent);
+        word-break: break-all;
+        user-select: all;
+    }
+}
+
+/* ── Sections (Abstract / BibTeX) ─────────────────────────────────────────── */
+
+.pub-item-section {
+    margin-block-end: 2.5rem;
+}
+
+.pub-item-section-title {
+    font-size: var(--fs-eyebrow);
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--main-color);
+    opacity: 0.4;
+    margin: 0 0 0.875rem;
+}
+
+.pub-item-abstract {
+    font-size: 1.0625rem;
+    line-height: 1.7;
+    color: var(--main-color);
+    margin: 0;
+}
+
+/* ── BibTeX block ─────────────────────────────────────────────────────────── */
+
+.pub-cite-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-block-end: 0.875rem;
+
+    .pub-item-section-title {
+        margin: 0;
+    }
+}
+
+.pub-copy-btn {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    padding: 0.35rem 0.8rem;
+    border: 0.0938rem solid color-mix(in srgb, var(--main-color) 22%, transparent);
+    border-radius: 2rem;
+    color: var(--main-color);
+    background: transparent;
+    cursor: pointer;
+    opacity: 0.7;
+    transition:
+        opacity var(--hover-transition-time),
+        border-color var(--hover-transition-time),
+        color var(--hover-transition-time);
+
+    &:hover {
+        opacity: 1;
+        border-color: color-mix(in srgb, var(--main-color) 45%, transparent);
+    }
+
+    &:focus-visible {
+        outline: 0.125rem solid var(--main-color);
+        outline-offset: 0.25rem;
+    }
+
+    &.is-copied {
+        opacity: 1;
+        color: var(--r-green);
+        border-color: color-mix(in srgb, var(--r-green) 45%, transparent);
+    }
+}
+
+/* Monospace is intentional here — a code/citation block is the one place the
+   universal Outfit/Noto stack should yield to a fixed-width face. */
+.pub-bibtex {
+    font-family: "SFMono-Regular", "SF Mono", "Menlo", "Consolas",
+                 "Liberation Mono", monospace;
+    font-size: 0.8125rem;
+    line-height: 1.6;
+    color: var(--main-color);
+    background: color-mix(in srgb, var(--main-color) 5%, transparent);
+    border: 0.0625rem solid color-mix(in srgb, var(--main-color) 12%, transparent);
+    border-radius: 0.5rem;
+    padding: 1.25rem 1.5rem;
+    margin: 0;
+    overflow-x: auto;
+    white-space: pre;
+    tab-size: 2;
+
+    & code {
+        font-family: inherit;
+    }
+}
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+
+/* Stack the columns; the metadata card moves above the reading content so the
+   publisher action stays visible without scrolling. */
+@media (max-width: 56rem) {
+    .pub-item-layout {
+        grid-template-columns: 1fr;
+        gap: 2rem;
+    }
+
+    .pub-item-aside {
+        order: -1;
+    }
+
+    .pub-meta-card {
+        position: static;
+    }
+}
+
+@media (max-width: 37.5rem) {
+    .pub-item-main {
+        padding-block: 2rem 5rem;
+    }
+
+    .pub-item-abstract {
+        font-size: 1rem;
+        line-height: 1.65;
+    }
+
+    .pub-bibtex {
+        padding: 1rem 1.1rem;
+    }
+}

--- a/static/css/subpage.css
+++ b/static/css/subpage.css
@@ -976,6 +976,115 @@
     }
 }
 
+/* ── Publication list rows: whole-row detail link + publisher opt-out ─────────
+   A row with a detail page is fully clickable: the title is a stretched link
+   whose ::after covers the row, so a click anywhere opens the detail page.
+   The Publisher button raises itself above that overlay (z-index) so it is the
+   single exception that goes to the journal. */
+
+.news-row--stretch {
+    position: relative;
+    /* keep .news-row's center alignment so the date sits mid-row */
+}
+
+.publications-subpage .news-row-title-link {
+    display: inline-block;
+    text-decoration: none;
+    color: inherit;
+
+    /* Stretch the click target across the whole row. */
+    &::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        z-index: 0;
+    }
+
+    /* Keyboard focus shows a ring on the title text, not the whole row. */
+    &:focus-visible {
+        outline: 0.125rem solid var(--main-color);
+        outline-offset: 0.2rem;
+        border-radius: 0.125rem;
+    }
+}
+
+/* Publisher opt-out button — raised above the stretched overlay. */
+.pub-row-publisher {
+    position: relative;
+    z-index: 1;
+    align-self: center;
+
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    white-space: nowrap;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    padding: 0.4rem 0.85rem;
+    border-radius: 2rem;
+    border: 0.0938rem solid color-mix(in srgb, var(--main-color) 25%, transparent);
+    color: var(--main-color);
+    background: var(--main-bg-color);
+    text-decoration: none;
+    transition:
+        background var(--hover-transition-time),
+        border-color var(--hover-transition-time);
+
+    & svg {
+        width: 0.8em;
+        height: 0.8em;
+        fill: currentColor;
+        flex-shrink: 0;
+        transition: translate var(--hover-transition-time);
+    }
+
+    &:hover, &:focus-visible {
+        border-color: color-mix(in srgb, var(--main-color) 50%, transparent);
+        background: color-mix(in srgb, var(--main-color) 7%, var(--main-bg-color));
+    }
+
+    &:hover svg, &:focus-visible svg {
+        translate: 0.1rem -0.1rem;
+    }
+
+    &:focus-visible {
+        outline: 0.125rem solid var(--main-color);
+        outline-offset: 0.15rem;
+    }
+}
+
+/* Topic tags — sit above the title, leading the row. */
+.pub-row-tags {
+    list-style: none;
+    margin: 0 0 0.4rem;
+    padding: 0;
+
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.pub-row-tag {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    line-height: 1.4;
+    padding: 0.1rem 0.6rem;
+    border-radius: 2rem;
+    color: var(--main-color-2);
+    background: color-mix(in srgb, var(--main-color-2) 12%, transparent);
+}
+
+/* Phone: collapse the publisher button to an icon. */
+@media (max-width: 37.5rem) {
+    .pub-row-publisher {
+        padding: 0.45rem 0.6rem;
+
+        & span { display: none; }
+    }
+}
+
 /* Extra items wrapper — transparent to layout, hidden by default */
 .publi-extra-item {
     display: contents;

--- a/templates/base.html
+++ b/templates/base.html
@@ -59,7 +59,7 @@
     <!-- css -->
     <link rel="stylesheet" href="/css/general.css?v=13">
     <link rel="stylesheet" href="/css/style.css?v=14">
-    <link rel="stylesheet" href="/css/subpage.css?v=34">
+    <link rel="stylesheet" href="/css/subpage.css?v=36">
 
     <!-- js -->
     <script defer src="/js/general.js?v=2"></script>

--- a/templates/pages/publications.html
+++ b/templates/pages/publications.html
@@ -100,55 +100,98 @@
     {% endif %}
     {% endmacro %}
 
-    {# ── Macro: render a single publication row ─────────────────────────────── #}
+    {# ── Macro: render the meta body shared by every row variant ─────────────
+       Order: status badge · topic tags · title · authors · journal · keywords.
+       Tags sit above the title so a row leads with its topics. #}
+    {% macro pub_row_body(item, status) %}
+        {% if status != 'published' %}
+        <span class="publi-status-badge" data-status="{{ status }}">
+            {%- if status == 'under-review' -%}Under Review{%- else -%}Submitted{%- endif -%}
+        </span>
+        {% endif %}
+        {% if item.get('tags') %}
+        <ul class="pub-row-tags" aria-label="Topics">
+            {% for tag in item['tags'] %}
+            <li class="pub-row-tag">{{ tag }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        {% if item.get('pageLink') %}
+        {# Stretched link: the ::after (CSS) covers the whole row so a click
+           anywhere opens the detail page. The publisher button opts out via
+           z-index. #}
+        <a class="news-row-title-link" href="{{ item['pageLink'] }}">
+            <p class="news-row-title">{{ item['title'] }}</p>
+        </a>
+        {% else %}
+        <p class="news-row-title">{{ item['title'] }}</p>
+        {% endif %}
+        {% if item.get('authors') %}
+        <span class="publi-row-authors">{{ item['authors'] }}</span>
+        {% endif %}
+        {% if item.get('journal') and status == 'published' %}
+        <span class="publi-row-journal">
+            {%- if item.get('volume') -%}{{ item['journal'] }}, Vol. {{ item['volume'] }}.{%- else -%}{{ item['journal'] }}.{%- endif -%}
+        </span>
+        {% endif %}
+        {% if item.get('keywords') %}
+        <div class="pub-keywords">
+          {% for _kw in item['keywords'] %}
+          <span class="pub-keyword-chip">{{ _kw }}</span>
+          {% endfor %}
+        </div>
+        {% endif %}
+    {% endmacro %}
+
+    {# ── Macro: render a single publication row ──────────────────────────────
+       Three shapes:
+       • detail page present → whole row links to the detail page (stretched
+         link); a single Publisher button is the only external opt-out.
+       • publisher link only → whole-row link to publisher (original behaviour).
+       • neither             → static row. #}
     {% macro pub_row(item) %}
     {% set status = item.get('status', 'published') %}
-    {% if item.get('link') %}
-    <a class="news-row news-row--link{% if status != 'published' %} news-row--no-date{% endif %}" href="{{ item['link'] }}" target="_blank" rel="noopener">
-    {% else %}
-    <div class="news-row{% if status != 'published' %} news-row--no-date{% endif %}">
-    {% endif %}
-
+    {% set detail = item.get('pageLink') %}
+    {% set publisher = item.get('link') %}
+    {% if detail %}
+    <div class="news-row news-row--link news-row--stretch{% if status != 'published' %} news-row--no-date{% endif %}">
         {% if status == 'published' %}
         <div class="news-row-date">
             <span class="news-row-mm">{{ item['month'] }}</span>
             <span class="news-row-yy">20{{ item['year'][1:] }}</span>
         </div>
         {% endif %}
-
-        <div class="news-row-body">
-            {% if status != 'published' %}
-            <span class="publi-status-badge" data-status="{{ status }}">
-                {%- if status == 'under-review' -%}Under Review{%- else -%}Submitted{%- endif -%}
-            </span>
-            {% endif %}
-            <p class="news-row-title">{{ item['title'] }}</p>
-            {% if item.get('authors') %}
-            <span class="publi-row-authors">{{ item['authors'] }}</span>
-            {% endif %}
-            {% if item.get('journal') and status == 'published' %}
-            <span class="publi-row-journal">
-                {%- if item.get('volume') -%}{{ item['journal'] }}, Vol. {{ item['volume'] }}.{%- else -%}{{ item['journal'] }}.{%- endif -%}
-            </span>
-            {% endif %}
-            {% if item.get('keywords') %}
-            <div class="pub-keywords">
-              {% for _kw in item['keywords'] %}
-              <span class="pub-keyword-chip">{{ _kw }}</span>
-              {% endfor %}
-            </div>
-            {% endif %}
+        <div class="news-row-body">{{ pub_row_body(item, status) }}</div>
+        {% if publisher %}
+        <a class="pub-row-publisher" href="{{ publisher }}" target="_blank" rel="noopener"
+           aria-label="View on publisher site">
+            <svg aria-hidden="true"><use href="/assets/sprite.svg#svg-arrow-top-right"></use></svg>
+            <span>Publisher</span>
+        </a>
+        {% endif %}
+    </div>
+    {% elif publisher %}
+    <a class="news-row news-row--link{% if status != 'published' %} news-row--no-date{% endif %}" href="{{ publisher }}" target="_blank" rel="noopener">
+        {% if status == 'published' %}
+        <div class="news-row-date">
+            <span class="news-row-mm">{{ item['month'] }}</span>
+            <span class="news-row-yy">20{{ item['year'][1:] }}</span>
         </div>
-
-        {% if item.get('link') %}
+        {% endif %}
+        <div class="news-row-body">{{ pub_row_body(item, status) }}</div>
         <span class="news-row-arrow" aria-hidden="true">
             <svg><use href="/assets/sprite.svg#svg-arrow-top-right"></use></svg>
         </span>
-        {% endif %}
-
-    {% if item.get('link') %}
     </a>
     {% else %}
+    <div class="news-row{% if status != 'published' %} news-row--no-date{% endif %}">
+        {% if status == 'published' %}
+        <div class="news-row-date">
+            <span class="news-row-mm">{{ item['month'] }}</span>
+            <span class="news-row-yy">20{{ item['year'][1:] }}</span>
+        </div>
+        {% endif %}
+        <div class="news-row-body">{{ pub_row_body(item, status) }}</div>
     </div>
     {% endif %}
     {% endmacro %}

--- a/templates/pages/publications/publication-item.html
+++ b/templates/pages/publications/publication-item.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {% set _short_title = pub.get('shortTitle') or pub['title'] %}
+    <title>{{ _short_title }} | E3 Center</title>
+    {% set _meta_desc = seo_meta_description(pub.get('abstract'), pub['title'] ~ ' — ' ~ pub.get('journal', '') ~ ', E3 Center, NTU.') %}
+    <meta name="description" content="{{ _meta_desc }}">
+    {% set _kw = (pub.get('tags') or []) + [pub.get('journal', ''), 'E3 Center', 'publication', 'sustainable energy', 'NTU', '台大', 'I-Yun Lisa Hsieh', '謝依芸'] %}
+    <meta name="keywords" content="{{ _kw | select | list | join(', ') }}">
+
+    <link rel="canonical" href="https://e3center.caece.net{{ pub['pageLink'] }}" />
+
+    <meta property="og:url" content="https://e3center.caece.net{{ pub['pageLink'] }}" />
+    <meta property="og:title" content="{{ _short_title }} | E3 Center" />
+    <meta property="og:type" content="article" />
+    <meta property="og:image" content="https://e3center.caece.net/assets/images/og-image-1200x630.png" />
+    <meta property="og:description" content="{{ _meta_desc }}" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="E3 Center" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="{{ _short_title }} | E3 Center" />
+    <meta name="twitter:description" content="{{ _meta_desc }}" />
+    <meta name="twitter:image" content="https://e3center.caece.net/assets/images/og-image-1200x630.png" />
+
+    <!-- Google Site Verification -->
+    <meta name="google-site-verification" content="YA_W9CdDDbSUMcW4Dr4CPEbGFWW61ZRHtBs-gmPTRlU" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JCJPED8JS6"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-JCJPED8JS6');
+    </script>
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M3L6SMNZ');</script>
+    <!-- End Google Tag Manager -->
+
+    <!-- google fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Outfit:wght@300..600&family=Noto+Sans+TC:wght@300..600&display=swap" as="style" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300..600&family=Noto+Sans+TC:wght@300..600&display=swap" rel="stylesheet" crossorigin>
+
+    <!-- css -->
+    <link rel="stylesheet" href="/css/general.css?v=13">
+    <link rel="stylesheet" href="/css/subpage.css?v=36">
+    <link rel="stylesheet" href="/css/publication-item.css?v=3">
+
+    <!-- js -->
+    <script defer src="/js/general.js"></script>
+
+    <!-- favicons -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicons/favicon-16x16.png">
+    <link rel="manifest" href="/assets/favicons/site.webmanifest">
+    <link rel="mask-icon" href="/assets/favicons/safari-pinned-tab.svg" color="#0a557e">
+    <meta name="msapplication-TileColor" content="#0a557e">
+    <meta name="theme-color" content="#ffffff">
+
+    {% set _yy = '20' ~ pub['year'][1:] if pub.get('year', '').startswith("'") else pub.get('year', '') %}
+    {% set month_map = {'Jan.': '01', 'Feb.': '02', 'Mar.': '03', 'Apr.': '04', 'May': '05', 'May.': '05', 'Jun.': '06', 'Jul.': '07', 'Aug.': '08', 'Sep.': '09', 'Oct.': '10', 'Nov.': '11', 'Dec.': '12'} %}
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ScholarlyArticle",
+      "@id": "https://e3center.caece.net{{ pub['pageLink'] }}#article",
+      "headline": {{ pub['title'] | tojson }},
+      "description": {{ _meta_desc | tojson }},
+      "url": "https://e3center.caece.net{{ pub['pageLink'] }}",
+      "mainEntityOfPage": { "@type": "WebPage", "@id": "https://e3center.caece.net{{ pub['pageLink'] }}" },
+      "datePublished": "{{ _yy }}-{{ month_map.get(pub.get('month'), '01') }}-01",
+      "inLanguage": "en",
+      "author": [
+        {% set _comma = joiner(", ") %}
+        {% for a in pub.get('authorList') or [] %}{{ _comma() }}{
+          "@type": "Person",
+          "name": {{ a['name'] | tojson }}{% if a.get('webId') and a['webId'] in member_ids %},
+          "url": "https://e3center.caece.net/members/{{ a['webId'] }}/"{% endif %}
+        }{% endfor %}
+      ],
+      {% if pub.get('journal') %}"isPartOf": {
+        "@type": "Periodical",
+        "name": {{ pub['journal'] | tojson }}{% if pub.get('volume') %},
+        "volumeNumber": {{ pub['volume'] | tojson }}{% endif %}
+      },
+      {% endif %}{% if pub.get('doi') %}"sameAs": "https://doi.org/{{ pub['doi'] }}",
+      {% endif %}"publisher": { "@id": "https://e3center.caece.net/#organization" }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://e3center.caece.net/" },
+        { "@type": "ListItem", "position": 2, "name": "Publications", "item": "https://e3center.caece.net/publications/" },
+        { "@type": "ListItem", "position": 3, "name": {{ pub['title'] | tojson }} }
+      ]
+    }
+    </script>
+</head>
+<body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M3L6SMNZ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    {% set subpageTitle = _short_title %}
+    {% set backLink = '/publications/' %}
+    {% set backLinkText = 'Publications' %}
+    {# The article renders its own visible h1 (.pub-item-title); suppress the sr-only one. #}
+    {% set suppressSrH1 = True %}
+    {% include 'partials/subpage-header.html' %}
+
+    <main class="pub-item-main">
+        {% set _pub_url = pub.get('link') or ('https://doi.org/' ~ pub['doi'] if pub.get('doi') else None) %}
+        <article class="pub-item-article">
+
+            <header class="pub-item-header">
+                {% if pub.get('tags') %}
+                <ul class="pub-item-tags" aria-label="Topics">
+                    {% for tag in pub['tags'] %}
+                    <li class="pub-tag-chip">{{ tag }}</li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+
+                <h1 class="pub-item-title">{{ pub['title'] }}</h1>
+
+                {% if pub.get('authorList') or pub.get('authors') %}
+                <p class="pub-item-authors">
+                    {% if pub.get('authorList') %}
+                        {% for a in pub['authorList'] -%}
+                        {%- if a.get('webId') and a['webId'] in member_ids -%}
+                        <a class="pub-author-link" href="/members/{{ a['webId'] }}/">{{ a['name'] }}</a>
+                        {%- else -%}
+                        <span>{{ a['name'] }}</span>
+                        {%- endif -%}
+                        {%- if not loop.last %}<span class="pub-author-sep">, </span>{% endif -%}
+                        {%- endfor %}
+                    {% else %}
+                        {{ pub['authors'] }}
+                    {% endif %}
+                </p>
+                {% endif %}
+            </header>
+
+            {# Two-column body: reading content on the left, a metadata card
+               (venue + publisher action + DOI) on the right. Stacks on narrow
+               viewports, with the card moving above the content. #}
+            <div class="pub-item-layout">
+                <div class="pub-item-content">
+                    {% if pub.get('abstract') %}
+                    <section class="pub-item-section" aria-labelledby="abstract-heading">
+                        <h2 id="abstract-heading" class="pub-item-section-title">Abstract</h2>
+                        <p class="pub-item-abstract">{{ pub['abstract'] }}</p>
+                    </section>
+                    {% endif %}
+
+                    {% if pub.get('bibtex') %}
+                    <section class="pub-item-section" aria-labelledby="bibtex-heading">
+                        <div class="pub-cite-header">
+                            <h2 id="bibtex-heading" class="pub-item-section-title">Cite (BibTeX)</h2>
+                            <button class="pub-copy-btn" type="button" data-copy-target="bibtex-block">
+                                <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none"
+                                     stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <rect x="9" y="9" width="13" height="13" rx="2"/>
+                                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+                                </svg>
+                                <span class="pub-copy-label">Copy</span>
+                            </button>
+                        </div>
+                        <pre class="pub-bibtex" id="bibtex-block"><code>{{ pub['bibtex'] }}</code></pre>
+                    </section>
+                    {% endif %}
+                </div>
+
+                <aside class="pub-item-aside">
+                    <div class="pub-meta-card">
+                        <p class="pub-meta-label">Published in</p>
+                        <p class="pub-meta-journal">{{ pub['journal'] }}</p>
+                        {% set _meta_bits = [] %}
+                        {%- if pub.get('volume') %}{% set _ = _meta_bits.append('Volume ' ~ pub['volume']) %}{% endif -%}
+                        {%- if pub.get('issue') %}{% set _ = _meta_bits.append('Issue ' ~ pub['issue']) %}{% endif -%}
+                        {%- if pub.get('articleNo') %}{% set _ = _meta_bits.append('Article ' ~ pub['articleNo']) %}{% elif pub.get('pages') %}{% set _ = _meta_bits.append('pp. ' ~ pub['pages']) %}{% endif -%}
+                        {%- if pub.get('year') %}{% set _ = _meta_bits.append(('20' ~ pub['year'][1:]) if pub['year'].startswith("'") else pub['year']) %}{% endif -%}
+                        {% if _meta_bits %}
+                        <p class="pub-meta-detail">{{ _meta_bits | join(' · ') }}</p>
+                        {% endif %}
+
+                        {% if _pub_url %}
+                        <a class="pub-action-btn skewed-block" b-role="btn" b-hoverable
+                           href="{{ _pub_url }}" target="_blank" rel="noopener">
+                            <span>View on publisher</span>
+                            <svg aria-hidden="true"><use href="/assets/sprite.svg#svg-arrow-top-right"></use></svg>
+                        </a>
+                        {% endif %}
+
+                        {% if pub.get('doi') %}
+                        <p class="pub-item-doi">DOI<span>{{ pub['doi'] }}</span></p>
+                        {% endif %}
+                    </div>
+                </aside>
+            </div>
+
+        </article>
+    </main>
+
+    {% include 'partials/footer.html' %}
+    {% include 'partials/background.html' %}
+    {% include 'partials/to-top-btn.html' %}
+    {% include 'partials/menu.html' %}
+
+    <script>
+        document.querySelectorAll('.pub-copy-btn').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var target = document.getElementById(btn.dataset.copyTarget);
+                if (!target) return;
+                var text = target.innerText;
+                var label = btn.querySelector('.pub-copy-label');
+                navigator.clipboard.writeText(text).then(function () {
+                    if (!label) return;
+                    var prev = label.textContent;
+                    label.textContent = 'Copied!';
+                    btn.classList.add('is-copied');
+                    setTimeout(function () {
+                        label.textContent = prev;
+                        btn.classList.remove('is-copied');
+                    }, 1800);
+                });
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds a standalone detail page for each publication, generated at build time, and links the publications listing into them.

- `build.py`: new `render_publication_pages` renders one page per publication
- `templates/pages/publications/publication-item.html`: new detail-page template (mirrors the news-item page conventions)
- `static/css/publication-item.css`: new styles for the detail page
- `templates/pages/publications.html`: row body refactored into a `pub_row_body` macro; rows with a `pageLink` become whole-row stretched links into the detail page, with the publisher link as the only external opt-out
- `contents/publications/publications.json`: `pageLink` wired for the detail-page publication
- `static/css/subpage.css`, `templates/base.html`: supporting styles + cache bump

## Integration note
This branch was rebased onto current `source`, which already carries PR #19 (publications styling: working-paper relabel, larger meta fonts, journal/keywords rendering). The merge conflict in `publications.html` / `base.html` was resolved so **both** survive — PR #19's richer body content now lives inside the shared `pub_row_body` macro, and the detail-page linking sits on top.

## Verification
`python build.py` succeeds; the built listing (`docs/publications/index.html`) contains both the detail-page links (`news-row-title-link`, `pub-row-publisher`) and PR #19's journal rendering (`publi-row-journal` ×31). A detail page (`docs/publications/2026-super-resolution-wind-mapping/`) is generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)