### PR TITLE
design: landing headings + filter UI + group-life marquee

### DIFF
--- a/contents/publications/publications.json
+++ b/contents/publications/publications.json
@@ -2180,7 +2180,7 @@
                 "citationId": "tUbPb-QAAAAJ:tam2025lcoctaiwan",
                 "title": "Assessment and Sensitivity Analysis of Electric Vehicle Charging Costs in Taiwan: A Levelized Cost Model Approach",
                 "titleZh": "臺灣電動車輛均化充電成本評估與敏感度分析",
-                "link": "",
+                "link": "https://www.airitilibrary.com/Article/Detail/10177159-N202603270008-00002",
                 "journal": "Transportation Planning Journal",
                 "journalZh": "運輸計劃季刊",
                 "volume": "54",

--- a/static/css/general.css
+++ b/static/css/general.css
@@ -527,7 +527,8 @@ section:has(.section-title) {
                 transition: width 280ms cubic-bezier(0.16, 1, 0.3, 1);
             }
 
-            &:hover {
+            &:hover,
+            &:focus-visible {
                 translate: calc(-1 * var(--block-hover-translate)) calc(-1 * var(--block-hover-translate));
 
                 &::after {
@@ -569,6 +570,44 @@ h3 {
         translate: 0 50%;
         background-color: var(--secondary-color);
     }
+}
+
+/* Editorial eyebrow label — quiet uppercase organizing label used on the
+   homepage for sub-groupings inside About Us / Members / News. Replaces the
+   default h3 (Title Case + trailing dot) so subheadings stop competing with
+   the section H2. Leading bar reads as a category mark, not a heading. */
+.section-eyebrow {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    line-height: 1.6;
+    color: var(--main-color);
+    opacity: 0.65;
+    margin-block: 3rem 1.25rem;
+
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+
+    &::before {
+        content: '';
+        width: 1.25rem;
+        height: 0.125rem;
+        background-color: var(--secondary-color);
+        flex-shrink: 0;
+    }
+
+    /* Suppress the default h3 trailing dot — the leading bar replaces it. */
+    &::after {
+        display: none;
+    }
+}
+
+/* First eyebrow inside a section can sit closer to the section title. */
+section:has(.section-title) > .section-eyebrow:first-of-type,
+section:has(.section-title) > *:first-of-type > .section-eyebrow:first-of-type {
+    margin-block-start: 0;
 }
 
 .filter {
@@ -1027,6 +1066,17 @@ body {
         right: calc(-100lvh * tan(var(--content-skew)) / 2 - 21rem);
         transition: right 0.25s cubic-bezier(0.16, 1, 0.3, 1);
     }
+}
+
+/* Scroll-spy active state — JS sets .menu-a--active + aria-current="location"
+   on the menu item matching the section currently in view. Inverted color
+   block reads as a quiet "you are here" without competing with hover state. */
+.menu-a--active {
+    background-color: var(--main-color);
+    color: var(--main-bg-color);
+}
+.menu-a--active svg {
+    fill: var(--main-bg-color);
 }
 
 /* sprite symbols */

--- a/static/css/news-item.css
+++ b/static/css/news-item.css
@@ -163,6 +163,13 @@
 }
 
 .news-item-body {
+    /* Cap prose width to the 65–75ch readability band. The wrapping
+       .news-item-article still extends to 68rem so the title and hero
+       image can use the full width; this rule only narrows the body
+       column. Images keep their 50%-of-parent width below. */
+    max-width: 75ch;
+    margin-inline: auto;
+
     font-size: 1.25rem;
     line-height: 1.7;
     color: var(--main-color);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -135,10 +135,6 @@
             justify-self: end;
             margin-inline-end: 1rem;
         }
-
-        .hp-scroll-for-more {
-            display: none;
-        }
     }
 
     /* Phone-only: drop secondary illustrations and compact remaining ones
@@ -146,8 +142,22 @@
     @media (max-width: 37.5rem) {
         --_home-min-height: 44rem;
 
-        .hp-small-no,
+        .hp-small-no {
+            display: none;
+        }
+
+        /* Keep About Us CTA visible — it's the only primary action above the
+           fold. Shrink to fit the narrower viewport rather than hide. */
         .hp-about-us {
+            --_adjusted-font-size: 1rem;
+            --_adjusted-padding: 0.625em 1.5em;
+            margin-inline-end: 0;
+        }
+
+        /* Scroll cue: keep on tablet (visible by default above), hide only on
+           very small phones where vertical space is tight and the CTA above
+           already invites engagement. */
+        .hp-scroll-for-more {
             display: none;
         }
 
@@ -1851,110 +1861,154 @@
 }
 
 
-/* group-life */
-.glf-section[which='slider'] {
-    --_img-width: min(40rem, calc(100vw - 5rem));
-    --_img-aspect-ratio: 4/3;
-    --_img-border-r: 0.375rem;
-    --_img-border-w: 0.1875rem;
+/* group-life — auto-scrolling marquee strip ─────────────────────────────────
+   Replaces the previous click-through slider. Photos drift horizontally at a
+   relaxed pace; hover/focus/touch-and-hold pauses the animation. The track
+   renders two identical copies of the photo set so the loop is seamless: when
+   the first copy has fully translated off-screen-left, the second copy is in
+   the same position the first started — the keyframe reset to translateX(0)
+   is invisible to the viewer. */
+.glf-marquee {
+    /* Card sizing — generous so each photo reads clearly when centred. */
+    --_card-w: clamp(22rem, 32vw, 30rem);
+    --_card-gap: 1.75rem;
+    --_card-pitch: calc(var(--_card-w) + var(--_card-gap));
 
-    --_block-skew: -1.5deg;
+    /* Step-pause cadence — N photos with a short slide between, then a hold
+       on each card. Must match `showInSlider` in
+       contents/group-life/group-life.json AND the number of keyframe pairs
+       in @keyframes glfMarqueeStepPause below. */
+    --_step-count: 10;
+    --_step-duration: 2.5s;
+    --_marquee-duration: calc(var(--_step-count) * var(--_step-duration));
 
-    --_block-width: calc(var(--_img-width) + 2 * var(--_img-border-w));
-    --_block-height: calc(var(--_img-width) / (var(--_img-aspect-ratio)) + 2 * var(--_img-border-w));
-
-    /* --_tan-theta: tan(calc(90 - abs(var(--_block-skew)))); */
-    --_tan-theta: calc(-1 / tan(var(--_block-skew)));
-    --_tan-theta-2: calc(var(--_tan-theta) / (1 + sqrt(1 + pow(var(--_tan-theta), 2))));
-
-    --_actural-block-width: calc(var(--_block-width) + (var(--_block-height) / var(--_tan-theta)) - 2 * var(--_img-border-r) * (1 - 1 / var(--_tan-theta-2)));
-    --_actural-content-width: calc(var(--_actural-block-width) - 2 * var(--_img-border-w));
-
-    --_slider-gap: 2rem;
+    /* The track contains 3 copies of N items (positions 0…3N-1). At step 0
+       we want copy-2 (middle copy)'s first item — track-index N — centred at
+       50vw. Each step slides left by one --_card-pitch so the next item in
+       copy 2 takes the centre. At step N we land on copy-3's first item,
+       which is visually identical to copy-2's first item → the keyframe loop
+       reset is invisible to the viewer. */
+    --_center-offset: calc(50vw - var(--_step-count) * var(--_card-pitch) - var(--_card-w) / 2);
 
     display: grid;
     justify-content: center;
-    justify-items: center;
+}
 
-    .glf-slider-header {
-        width: var(--_img-width);
+.glf-marquee-viewport {
+    width: 100%;
+    overflow: hidden;
+    /* Soft edge fades so cards enter/exit the strip gracefully. */
+    -webkit-mask-image: linear-gradient(to right, transparent, #000 3rem, #000 calc(100% - 3rem), transparent);
+            mask-image: linear-gradient(to right, transparent, #000 3rem, #000 calc(100% - 3rem), transparent);
+}
 
-        display: flex;
-        flex-wrap: wrap;
-        align-items: baseline;
-        justify-content: space-between;
+.glf-marquee-track {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--_card-gap);
+    width: max-content;
+    padding-block: 0.75rem;
+    animation: glfMarqueeStepPause var(--_marquee-duration) ease-in-out infinite;
+    will-change: transform;
+}
 
-        .glf-slider-btns {
-            margin-block-end: 0.8rem;
+/* Pause when the user shows intent to engage. :hover for pointer, :focus-within
+   for keyboard, :active covers touch-and-hold on phones. */
+.glf-marquee:hover .glf-marquee-track,
+.glf-marquee:focus-within .glf-marquee-track,
+.glf-marquee:active .glf-marquee-track {
+    animation-play-state: paused;
+}
 
-            display: flex;
-            align-items: center;
-            gap: 0.625rem;
+/* Each 10% slice = one card: 0–8% hold, 8–10% smooth slide to the next.
+   That gives ~2s hold + ~0.5s slide per card at --_step-duration: 2.5s.
+   Keyframe values offset --_center-offset by k card-pitches; at 100% we land
+   on copy-3's first item, identical to copy-2's first item → loop reset is
+   invisible. */
+@keyframes glfMarqueeStepPause {
+    0%,   8%  { transform: translateX(calc(var(--_center-offset) -  0 * var(--_card-pitch))); }
+    10%,  18% { transform: translateX(calc(var(--_center-offset) -  1 * var(--_card-pitch))); }
+    20%,  28% { transform: translateX(calc(var(--_center-offset) -  2 * var(--_card-pitch))); }
+    30%,  38% { transform: translateX(calc(var(--_center-offset) -  3 * var(--_card-pitch))); }
+    40%,  48% { transform: translateX(calc(var(--_center-offset) -  4 * var(--_card-pitch))); }
+    50%,  58% { transform: translateX(calc(var(--_center-offset) -  5 * var(--_card-pitch))); }
+    60%,  68% { transform: translateX(calc(var(--_center-offset) -  6 * var(--_card-pitch))); }
+    70%,  78% { transform: translateX(calc(var(--_center-offset) -  7 * var(--_card-pitch))); }
+    80%,  88% { transform: translateX(calc(var(--_center-offset) -  8 * var(--_card-pitch))); }
+    90%,  98% { transform: translateX(calc(var(--_center-offset) -  9 * var(--_card-pitch))); }
+    100%      { transform: translateX(calc(var(--_center-offset) - 10 * var(--_card-pitch))); }
+}
 
-            & svg:has(use[href*="#svg-slider-"]) {
-                width: 0.8125rem;
-            }
-        }
+.glf-marquee-item {
+    width: var(--_card-w);
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+    user-select: none;
+    flex-shrink: 0;
+}
 
-        .glf-slider-num {
-            width: 3.8125rem;
-            margin-inline-start: 0.125rem;
-            font-size: 1.25rem;
-            text-align: center;
-        }
-    }
+.glf-marquee-img {
+    --_block-skew: -1.5deg;
+    --_adjusted-block-skew: var(--_block-skew);
+    --_adjusted-border-width: 0.1875rem;
+    --_adjusted-border-radius: 0.375rem;
+    --_adjusted-shadow-shift: var(--block-shadow-shift);
 
-    .glf-slider {
+    /* Required by .skewed-block[b-role="block"]'s sizing rule — without
+       these the wrapper collapses to 0×0 and the photo is invisible. The
+       wrapper fills its grid cell; aspect-ratio gives it height; the inner
+       <img> fills the wrapper via --_content-width. */
+    --_block-width: 100%;
+    --_block-height: auto;
+    --_content-width: 100%;
+
+    aspect-ratio: 4/3;
+    width: 100%;
+
+    & img {
         width: 100%;
-        padding-block-start: 0.5rem;
-        transform: translateY(-0.5rem);
-        overflow: hidden;
+        height: 100%;
+        /* `cover` fills the 4:3 frame edge-to-edge; portrait shots are
+           softly cropped top/bottom, landscape shots crop sides. */
+        object-fit: cover;
     }
+}
 
-    .glf-slider-wrapper {
-        --_slider-transition-time: 0.4s;
-        --_slide-to: 0;
-        transform: translateX(calc(50% - (var(--_img-width) + var(--_slider-gap)) * var(--_slide-to)));
-        transition: var(--_slider-transition-time) cubic-bezier(0.3, 0.2, 0.2, 1.2);
+.glf-marquee-caption {
+    display: grid;
+    gap: 0.25rem;
+    text-align: center;
+    padding-inline: 0.25rem;
+}
 
-        display: flex;
-        align-items: start;
-        gap: var(--_slider-gap);
-    }
+.glf-marquee-date {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--main-color);
+    opacity: 0.55;
+}
 
-    .glf-slider-block {
-        transform: translateX(-50%);
-        transition: calc(var(--_slider-transition-time) / 2);
-        user-select: none;
+.glf-marquee-desc {
+    font-size: 0.9375rem;
+    line-height: 1.45;
+    color: var(--main-color);
+    text-wrap: balance;
+    /* Cap to 3 lines so every card has equal visual height. */
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
 
-        &+* {
-            opacity: 0;
-        }
-
-        .glf-slider-img {
-            --_adjusted-block-skew: var(--_block-skew);
-            --_adjusted-content-skew: calc(-1 * var(--_block-skew));
-
-            --_block-width: calc(var(--_img-width) + 0 * var(--_img-border-w));
-            --_block-height: calc((var(--_img-width) + 2 * var(--_img-border-w)) / (var(--_img-aspect-ratio)));
-            --_adjusted-border-width: var(--_img-border-w);
-            --_adjusted-border-radius: var(--_img-border-r);
-            --_adjusted-shadow-shift: var(--block-shadow-shift);
-            --_adjusted-hover-shadow-shift: var(--block-hover-shadow-shift);
-            --_content-width: var(--_actural-content-width);
-
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        .glf-slider-text {
-            width: var(--_img-width);
-            margin-block-start: 0.75rem;
-            font-size: 1.25rem;
-            text-wrap: balance;
-            text-align: center;
-        }
+/* Accessibility: stop the animation for users who prefer reduced motion.
+   They still see the first set of cards; the "View all photos" CTA below
+   provides full access to the gallery. */
+@media (prefers-reduced-motion: reduce) {
+    .glf-marquee-track {
+        animation: none;
     }
 }
 
@@ -2306,19 +2360,21 @@
         }
     }
 
-    .glf-section[which='slider'] {
-        .glf-slider-btns svg {
-            width: 0.625rem;
-        }
-
-        .glf-slider-num {
-            width: 3.4375rem !important;
-            font-size: 1.125rem !important;
-        }
+    .glf-marquee {
+        /* Phone: card fills most of the screen width; cadence stays at 2.5s
+           per step (≈2s pause + ≈0.5s slide). */
+        --_card-w: min(20rem, calc(100vw - 4rem));
+        --_card-gap: 1rem;
+        --_step-duration: 2.5s;
     }
 
-    .glf-slider-text {
-        font-size: 1.125rem !important;
+    .glf-marquee-viewport {
+        -webkit-mask-image: linear-gradient(to right, transparent, #000 1.25rem, #000 calc(100% - 1.25rem), transparent);
+                mask-image: linear-gradient(to right, transparent, #000 1.25rem, #000 calc(100% - 1.25rem), transparent);
+    }
+
+    .glf-marquee-desc {
+        font-size: 0.875rem;
     }
 }
 

--- a/static/css/subpage.css
+++ b/static/css/subpage.css
@@ -1832,7 +1832,20 @@
     top: calc(100% + 0.375rem);
     left: 0;
     z-index: 50;
-    min-width: 100%;
+    /* All five filters (Year / Journal / Topic / Method / Type) share the
+       same panel footprint so the bar feels like one set of controls. The
+       min-width is wide enough that a Year row ("2024 · 12") sits comfortably,
+       and Journal/Topic/Method rows don't crowd. max-width caps the panel on
+       desktop; max-height + overflow-y handles long lists (mostly Journal). */
+    min-width: 16rem;
+    max-width: min(28rem, calc(100vw - 2rem));
+    max-height: 22rem;
+    overflow-y: auto;
+    /* Reserve scrollbar space whether or not it's actually needed, so panels
+       that scroll (Year / Journal / Topic / Method) have the same content
+       width as panels that don't (Type). Without this, the scrollbar steals
+       ~10px on scroll-triggering panels and rows look misaligned vs Type. */
+    scrollbar-gutter: stable;
     padding: 0.375rem;
     border: 0.125rem solid var(--main-color);
     border-radius: 0.75rem;
@@ -1840,7 +1853,9 @@
     box-shadow: 0.25rem 0.25rem 0 var(--main-shadow-color);
     display: flex;
     flex-direction: column;
-    gap: 0.125rem;
+    /* 2px was too tight — rows visually merged. 4px gives clear separation
+       between filter options without bloating the panel. */
+    gap: 0.25rem;
 }
 
 .pub-filter-panel[hidden] { display: none; }
@@ -1849,7 +1864,11 @@
     display: flex;
     align-items: center;
     gap: 0.625rem;
-    padding: 0.5rem 0.75rem;
+    /* Fixed row height across every filter (Year / Journal / Topic / Method /
+       Type) so the dropdowns read as a uniform grid regardless of which
+       items they contain or whether the label has a leading color dot. */
+    min-height: 2.5rem;
+    padding: 0.375rem 0.75rem;
     border-radius: 0.5rem;
     font-size: 0.875rem;
     font-weight: 500;
@@ -1865,12 +1884,16 @@
         background var(--hover-transition-time),
         opacity 150ms ease,
         max-height 200ms ease,
+        min-height 200ms ease,
         padding-block 150ms ease;
 }
 
 .pub-filter-check.is-suppressed {
     opacity: 0;
+    /* Must zero out BOTH max-height and min-height — without overriding the
+       min-height baseline, the row would refuse to collapse. */
     max-height: 0;
+    min-height: 0;
     padding-block: 0;
     pointer-events: none;
 }
@@ -1898,10 +1921,16 @@
     font-weight: 600;
 }
 
-/* Label takes remaining width so the count chip sits flush right. */
+/* Label takes remaining width so the count chip sits flush right. Single-
+   line + ellipsis ensures every filter row has the same height regardless
+   of label length (long journal names truncate; full text is preserved in
+   the parent <label>'s title attribute for hover/tap-and-hold). */
 .pub-filter-check-label {
     flex: 1;
     min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 /* Per-option count — right-aligned, muted, tabular numerals so the
@@ -1924,24 +1953,6 @@
 .pub-filter-check:has(input:checked) .pub-filter-check-count {
     background: color-mix(in srgb, var(--main-color) 14%, transparent);
     color: var(--main-color);
-}
-
-/* Journal / Topic / Method panels are wider (long values) and scrollable
-   when the list outgrows a comfortable visible count. */
-.pub-filter-dropdown--journal .pub-filter-panel,
-.pub-filter-dropdown--topic   .pub-filter-panel,
-.pub-filter-dropdown--method  .pub-filter-panel {
-    min-width: 18rem;
-    max-width: min(28rem, calc(100vw - 2rem));
-    max-height: 22rem;
-    overflow-y: auto;
-}
-
-.pub-filter-dropdown--journal .pub-filter-check .pub-filter-check-label,
-.pub-filter-dropdown--topic   .pub-filter-check .pub-filter-check-label,
-.pub-filter-dropdown--method  .pub-filter-check .pub-filter-check-label {
-    white-space: normal;
-    line-height: 1.35;
 }
 
 /* Topic / method options carry a small color swatch so the dropdown
@@ -2122,9 +2133,10 @@
         max-width: none;
     }
 
-    /* Phone journal panel: cap width to viewport so a long-named journal
-       never pushes the page horizontally. */
-    .pub-filter-dropdown--journal .pub-filter-panel {
+    /* Phone: every panel shrinks to fit a small viewport. Min stays
+       comfortable, max strictly caps to (viewport - 2rem) so a long-named
+       journal never pushes the page horizontally. */
+    .pub-filter-panel {
         min-width: 14rem;
         max-width: calc(100vw - 2rem);
     }

--- a/static/js/general.js
+++ b/static/js/general.js
@@ -226,6 +226,40 @@ document.querySelectorAll('.filter').forEach((filter) => {
     updateEmptyState();
 });
 
+// Scroll-spy: highlight the menu item matching the section currently in view.
+// Only runs on the homepage (presence of `<section id="home">`). For each
+// homepage section, find a `.menu-a` whose href ends with `#<id>` (anchor link)
+// or `/<id>` (subpage link with matching slug). When that section's top crosses
+// the upper viewport band, mark its menu item `.menu-a--active` + aria-current.
+if (document.querySelector('section#home')) {
+    const sections = Array.from(document.querySelectorAll('section[id]'))
+        .filter(s => s.id !== 'home');
+    const linkBySection = {};
+    sections.forEach(s => {
+        const id = s.id;
+        let link = document.querySelector(`.menu-a[href="/#${id}"], .menu-a[href="#${id}"]`);
+        if (!link) link = document.querySelector(`.menu-a[href$="/${id}"], .menu-a[href$="/${id}/"]`);
+        if (link) linkBySection[id] = link;
+    });
+    const links = Object.values(linkBySection);
+    if (links.length) {
+        const setActive = (activeId) => {
+            Object.entries(linkBySection).forEach(([id, link]) => {
+                const isActive = id === activeId;
+                link.classList.toggle('menu-a--active', isActive);
+                if (isActive) link.setAttribute('aria-current', 'location');
+                else link.removeAttribute('aria-current');
+            });
+        };
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) setActive(entry.target.id);
+            });
+        }, { rootMargin: '-20% 0px -75% 0px', threshold: 0 });
+        sections.forEach(s => observer.observe(s));
+    }
+}
+
 // Member page — publication section "Show all N" / "Show less" toggle.
 // Reveals .pub-row--extra siblings within the same .pub-list. Toggling
 // .pub-list--expanded on the list lets CSS handle the peek-mask, backdrop

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -210,69 +210,9 @@ resBlockWithAni.forEach(block => {
     });
 });
 
-// * no priority
-// group life slider
-const glfSlider = document.querySelector('.glf-slider');
-const glfSliderCurrentNum = document.querySelector('.glf-slider-current-num');
-const glfSliderTotalNum = document.querySelector('.glf-slider-total-num');
-const glfSliderWrapper = document.querySelector('.glf-slider-wrapper');
-const glfSliderBlock = document.querySelectorAll('.glf-slider-block');
-const glfSliderBlockNum = document.querySelectorAll('.glf-slider-block').length;
-const blockNumMax = glfSliderBlockNum - 1;
-
-function glfSliderHandleSwipe(glfSliderTouchEndX) {
-    if (glfSliderTouchStartX - glfSliderTouchEndX > 50) {
-        glfSliderPush(1);
-    } else if (glfSliderTouchEndX - glfSliderTouchStartX > 50) {
-        glfSliderPush(-1);
-    };
-};
-
-glfSliderWrapper.style.setProperty('--_slide-to', 0);
-glfSliderCurrentNum.innerHTML = 1;
-glfSliderTotalNum.innerHTML = glfSliderBlockNum;
-
-let glfSliderTo = 0;
-function glfSliderPush(push) {
-    glfSliderBlock[glfSliderTo].style.setProperty('opacity', 0);
-
-    glfSliderTo += push;
-    glfSliderTo = glfSliderTo < 0 ? 0 : glfSliderTo;
-    glfSliderTo = glfSliderTo > blockNumMax ? blockNumMax : glfSliderTo;
-    glfSliderWrapper.style.setProperty('--_slide-to', glfSliderTo);
-
-    glfSliderCurrentNum.innerHTML = glfSliderTo + 1;
-
-    glfSliderBlock[glfSliderTo].style.setProperty('opacity', 1);
-};
-
-let glfSliderTouchStartX = 0;
-let glfSliderTouchIsDown = false;
-
-glfSlider.addEventListener('mousedown', (e) => {
-    glfSliderTouchIsDown = true;
-    glfSliderTouchStartX = e.pageX;
-});
-
-glfSlider.addEventListener('mouseup', (e) => {
-    if (!glfSliderTouchIsDown) return;
-    glfSliderTouchIsDown = false;
-    glfSliderHandleSwipe(e.pageX);
-});
-
-glfSlider.addEventListener('mouseleave', () => {
-    glfSliderTouchIsDown = false;
-});
-
-glfSlider.addEventListener('touchstart', (e) => {
-    glfSliderTouchStartX = e.touches[0].clientX;
-});
-
-glfSlider.addEventListener('touchend', (e) => {
-    const glfSliderTouchEndX = e.changedTouches[0].clientX;
-    glfSliderHandleSwipe(glfSliderTouchEndX);
-});
-
+// group-life now uses a CSS-only auto-scroll marquee (see .glf-marquee in
+// style.css). No JS needed — pause-on-hover is handled by CSS, the seamless
+// loop comes from rendering two copies of the photo set in the template.
 
 // * no priority
 // --- MODAL SETUP ---

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,12 +57,12 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300..600&family=Noto+Sans+TC:wght@300..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=17">
-    <link rel="stylesheet" href="/css/style.css?v=14">
-    <link rel="stylesheet" href="/css/subpage.css?v=46">
+    <link rel="stylesheet" href="/css/general.css?v=19">
+    <link rel="stylesheet" href="/css/style.css?v=20">
+    <link rel="stylesheet" href="/css/subpage.css?v=51">
 
     <!-- js -->
-    <script defer src="/js/general.js?v=2"></script>
+    <script defer src="/js/general.js?v=3"></script>
     {% if isHomePage %}
     <script defer src="/js/script.js"></script>
     {% endif %}

--- a/templates/home/about.html
+++ b/templates/home/about.html
@@ -6,7 +6,8 @@
 
     {% for about in structures['about'] %}
     {% if about['form'] == 'about' %}
-    <h3>{{ about['sectionTitle'] }}</h3>
+    {# Main about content carries the section identity — no eyebrow needed
+       (would just repeat "About Us"). Eyebrow only appears for Sponsors. #}
     <section class="abt-section" which="{{ about['form'] }}">
         <div class="abt-text">
             {% set articleVar = about['article'].split('/')[-1].split('.')[0] %}
@@ -20,7 +21,7 @@
         </div>
     </section>
     {% elif about['form'] == 'sponsors' and about['display'] %}
-    <h3>{{ about['sectionTitle'] }}</h3>
+    <h3 class="section-eyebrow">{{ about['sectionTitle'] }}</h3>
     <section class="abt-section" which="{{ about['form'] }}">
         {% for logo in about['logos'] %}
         <a{% if logo['logoLink'] %} href="{{ logo['logoLink'] }}" target="_blank"{% endif %}>

--- a/templates/home/group-life.html
+++ b/templates/home/group-life.html
@@ -1,36 +1,25 @@
 <section id="group-life">
     <div class="section-title">
-        <h2><a class="section-title-link" href="/group-life/">Group Life</a></h2>
+        <h2><a class="section-title-link" href="/group-life/">From the Group</a></h2>
     </div>
 
     {% for group_life in structures['group-life'] %}
-    <section class="glf-section" which="slider">
-        <div class="glf-slider-header">
-            <h3>{{ group_life['sliderTitle'] }}</h3>
-
-            <div class="glf-slider-btns">
-                <button type="button" class="glf-slider-btn skewed-block" b-role="btn" b-hoverable onclick="glfSliderPush(-1)" aria-label="Last Photo">
-                    <svg><use href="/assets/sprite.svg#svg-slider-left"></use></svg>
-                </button>
-
-                <div class="glf-slider-num">
-                    <span class="glf-slider-current-num">1</span>
-                    <span>/</span>
-                    <span class="glf-slider-total-num">{{ group_life['showInSlider'] }}</span>
-                </div>
-
-                <button type="button" class="glf-slider-btn skewed-block" b-role="btn" b-hoverable onclick="glfSliderPush(1)" aria-label="Next Photo">
-                    <svg><use href="/assets/sprite.svg#svg-slider-right"></use></svg>
-                </button>
-            </div>
-        </div>
-
-        <div class="glf-slider">
-            <div class="glf-slider-wrapper">
-                {% for item in group_life['items'][-1:(-1-group_life['showInSlider']):-1] %}
-                <div class="glf-slider-block" current-slide="{% if loop.index == 1 %}true{% else %}false{% endif %}">
-                    {% set imgPathFront = item['imgPath'].split('.')[0] %}
-                    <div class="glf-slider-img skewed-block" b-role="block" style="background-image: url({{ imgPathFront }}-20w.webp);">
+    {% set marquee_items = group_life['items'][-1:(-1-group_life['showInSlider']):-1] %}
+    <div class="glf-marquee" aria-roledescription="carousel" aria-label="Group life photos — drifts automatically; hover or focus to pause">
+        <div class="glf-marquee-viewport">
+            {# Three identical copies of the photo set form one continuous
+               strip. The animation always keeps the MIDDLE copy in view —
+               copies 1 and 3 act as visual buffers so the wrap-around moment
+               (last photo next to first photo) is visible at every frame.
+               Copies 2 and 3 are aria-hidden so screen readers only announce
+               each photo once. The loop reset is invisible because copy 3's
+               first item lands in the same place copy 2's first item started. #}
+            <div class="glf-marquee-track">
+                {% for _copy in [0, 1, 2] %}
+                {% for item in marquee_items %}
+                {% set imgPathFront = item['imgPath'].split('.')[0] %}
+                <figure class="glf-marquee-item"{% if _copy != 0 %} aria-hidden="true"{% endif %}>
+                    <div class="glf-marquee-img skewed-block" b-role="block" style="background-image: url({{ imgPathFront }}-20w.webp);">
                         <img
                             loading="lazy"
                             src="{{ item['imgPath'] }}"
@@ -38,25 +27,23 @@
                                 {{ imgPathFront }}-200w.webp 200w,
                                 {{ imgPathFront }}-400w.webp 400w,
                                 {{ imgPathFront }}-600w.webp 600w,
-                                {{ imgPathFront }}-800w.webp 800w,
-                                {{ imgPathFront }}-1200w.webp 1200w,
-                                {{ imgPathFront }}-1600w.webp 1600w,
-                                {{ imgPathFront }}-2000w.webp 2000w
+                                {{ imgPathFront }}-800w.webp 800w
                             "
-                            sizes="(max-width: 45rem) 100svw, 45rem"
+                            sizes="(max-width: 45rem) 70vw, 22rem"
                             alt="{{ item['month'] }} {{ item['year'] }}. {{ item['description'] }}"
                             draggable="false"
                         />
                     </div>
-
-                    <div class="glf-slider-text">
-                        {{ item['month'] }} {{ item['year'] }}. {{ item['description'] }}
-                    </div>
-                </div>
+                    <figcaption class="glf-marquee-caption">
+                        <span class="glf-marquee-date">{{ item['month'] }} {{ item['year'] }}</span>
+                        <span class="glf-marquee-desc">{{ item['description'] }}</span>
+                    </figcaption>
+                </figure>
+                {% endfor %}
                 {% endfor %}
             </div>
         </div>
-    </section>
+    </div>
     {% endfor %}
 
     <div class="section-cta">

--- a/templates/home/members.html
+++ b/templates/home/members.html
@@ -6,7 +6,7 @@
     {% for members in structures['members'] %}
     {% if not (isHomePage and members['sectionTitle'] in ['Master Students', 'Alumni']) %}
     {% if members['form'] == 'L' %}
-    <h3>{{ members['sectionTitle'] }}</h3>
+    <h3 class="section-eyebrow">{{ members['sectionTitle'] }}</h3>
     <section class="mem-section" who="{{ members['form'] }}">
         {% for member in members['members'] %}
         {% set imgPathFront = member['imgPath'].split('.')[0] %}
@@ -43,7 +43,7 @@
         {% endfor %}
     </section>
     {% elif members['form'] == 'M' %}
-    <h3>{{ members['sectionTitle'] }}</h3>
+    <h3 class="section-eyebrow">{{ members['sectionTitle'] }}</h3>
     <section class="mem-section" who="{{ members['form'] }}">
         {% for member in members['members'] %}
         {% set imgPathFront = member['imgPath'].split('.')[0] %}
@@ -81,7 +81,7 @@
         {% endfor %}
     </section>
     {% elif members['form'] == 'S' %}
-    <h3>{{ members['sectionTitle'] }}</h3>
+    <h3 class="section-eyebrow">{{ members['sectionTitle'] }}</h3>
     {% if members['filter'] %}
     <div class="filter" where="{{ members['filterId'] }}">
         <span class="filter-title">{{ members['filterTitle'] }}</span>

--- a/templates/home/news.html
+++ b/templates/home/news.html
@@ -3,11 +3,18 @@
         <h2><a class="section-title-link" href="/news/">News</a></h2>
     </div>
 
-    {% for news in structures['news'] %}
+    {# Flatten items across all news entries before grouping by category, so
+       the three category H3s render once even if multiple news structures
+       are added later. Empty categories are skipped to avoid bare headings. #}
     {% set category_order = ['Honors and Recognitions', 'Events and Exchanges', 'Community and Outreach'] %}
+    {% set ns = namespace(all_items=[]) %}
+    {% for news in structures['news'] %}
+        {% set ns.all_items = ns.all_items + news['items'] %}
+    {% endfor %}
     {% for category in category_order %}
-    {% set cat_items = news['items'] | selectattr('category', 'equalto', category) | list %}
-    <h3>{{ category }}</h3>
+    {% set cat_items = ns.all_items | selectattr('category', 'equalto', category) | list %}
+    {% if cat_items %}
+    <h3 class="section-eyebrow">{{ category }}</h3>
     <div class="news-rows">
         {% for item in cat_items[-2:] | reverse %}
         {% if item.get('pageLink') %}
@@ -42,7 +49,7 @@
         {% endif %}
         {% endfor %}
     </div>
-    {% endfor %}
+    {% endif %}
     {% endfor %}
 
     <div class="section-cta">

--- a/templates/home/projects.html
+++ b/templates/home/projects.html
@@ -1,7 +1,7 @@
 {% from 'partials/proj-row.html' import proj_row %}
 <section id="projects">
     <div class="section-title">
-        <h2><a class="section-title-link" href="/projects/">Projects</a></h2>
+        <h2><a class="section-title-link" href="/projects/">Featured Projects</a></h2>
     </div>
 
     {# Collect every project, surface the most recently started ongoing ones —
@@ -21,7 +21,6 @@
 
     {% if ongoing %}
     <div class="publi-group">
-        <h3 class="publi-group-title">Currently Ongoing</h3>
         <div class="news-rows" role="list">
             {% for item in ongoing[:5] %}
             {{ proj_row(item) }}

--- a/templates/home/publications.html
+++ b/templates/home/publications.html
@@ -1,13 +1,12 @@
 <section id="publications">
     <div class="section-title">
-        <h2><a class="section-title-link" href="/publications/">Publications</a></h2>
+        <h2><a class="section-title-link" href="/publications/">Recent Publications</a></h2>
     </div>
 
     {% for publication in structures['home_publications'] %}
     {% set home_items = publication['items'][:publication['showInHome']] %}
     {% if home_items %}
     <div class="publi-group" id="home-pub-{{ loop.index }}">
-        <h3 class="publi-group-title">Recent Publications</h3>
         <div class="news-rows">
             {% for item in home_items %}
             {% set status = item.get('status', 'published') %}

--- a/templates/home/research.html
+++ b/templates/home/research.html
@@ -22,7 +22,6 @@
     </div>
 
     {% for research in structures['research'] %}
-    <h3>{{ research['sectionTitle'] }}</h3>
     <section class="res-section"  topic-type="ongoing">
         {% for topic in research['topics'] %}
         <div class="res-block">

--- a/templates/home/videos.html
+++ b/templates/home/videos.html
@@ -1,11 +1,10 @@
 <section id="videos">
     <div class="section-title">
-        <h2>Videos</h2>
+        <h2>Featured Videos</h2>
 
     </div>
 
 {% for video in structures['videos'] %}
-    <h3>{{ video['sectionTitle'] }}</h3>
     {% if video['filter'] %}
     <div class="filter" where="{{ video['filterId'] }}">
         <span class="filter-title">{{ video['filterTitle'] }}</span>

--- a/templates/pages/member/member.html
+++ b/templates/pages/member/member.html
@@ -91,8 +91,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@500..600&family=Noto+Sans+TC:wght@500..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=17">
-    <link rel="stylesheet" href="/css/subpage.css?v=46">
+    <link rel="stylesheet" href="/css/general.css?v=19">
+    <link rel="stylesheet" href="/css/subpage.css?v=51">
     <link rel="stylesheet" href="/css/member.css?v=18">
 
     <!-- js -->

--- a/templates/pages/news/news-item.html
+++ b/templates/pages/news/news-item.html
@@ -55,9 +55,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@500..600&family=Noto+Sans+TC:wght@500..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=17">
-    <link rel="stylesheet" href="/css/subpage.css?v=46">
-    <link rel="stylesheet" href="/css/news-item.css?v=4">
+    <link rel="stylesheet" href="/css/general.css?v=19">
+    <link rel="stylesheet" href="/css/subpage.css?v=51">
+    <link rel="stylesheet" href="/css/news-item.css?v=5">
 
     <!-- js -->
     <script defer src="/js/general.js"></script>

--- a/templates/pages/publications.html
+++ b/templates/pages/publications.html
@@ -300,7 +300,11 @@
         {% endfor %}
     {% endfor %}
     {% set years_sorted    = _year_counts.keys()    | list | sort(reverse=True) %}
-    {% set journals_sorted = _journal_counts.keys() | list | sort(case_sensitive=False) %}
+    {# Journals sort by count desc, alpha tiebreaker — matches the topic/method
+       behaviour below so all three multi-value facets read the same way and
+       the genuinely useful filters (journals with 2+ papers) surface above
+       the long tail of singletons. #}
+    {% set journals_sorted = _journal_counts | dictsort(by='value', reverse=True) | map(attribute=0) | list %}
     {# Topics + Methods sort by count desc, then alpha — most-used tags
        surface at the top so the filter feels weighted to what's actually
        in the catalogue. #}
@@ -349,7 +353,7 @@
             <div class="pub-filter-panel" id="pub-journal-panel" role="group"
                  aria-label="Filter publications by journal" hidden>
                 {% for j in journals_sorted %}
-                <label class="pub-filter-check">
+                <label class="pub-filter-check" title="{{ j }}">
                     <input type="checkbox" class="pub-filter-journal-input" data-journal="{{ j }}">
                     <span class="pub-filter-check-label">{{ j }}</span>
                     <span class="pub-filter-check-count" aria-hidden="true">{{ _journal_counts[j] }}</span>
@@ -373,7 +377,7 @@
             <div class="pub-filter-panel" id="pub-topic-panel" role="group"
                  aria-label="Filter publications by topic" hidden>
                 {% for t in topics_sorted %}
-                <label class="pub-filter-check pub-filter-check--topic">
+                <label class="pub-filter-check pub-filter-check--topic" title="{{ t }}">
                     <input type="checkbox" class="pub-filter-topics-input" data-topics="{{ t }}">
                     <span class="pub-filter-check-label">{{ t }}</span>
                     <span class="pub-filter-check-count" aria-hidden="true">{{ _topic_counts[t] }}</span>
@@ -397,7 +401,7 @@
             <div class="pub-filter-panel" id="pub-method-panel" role="group"
                  aria-label="Filter publications by method" hidden>
                 {% for m in methods_sorted %}
-                <label class="pub-filter-check pub-filter-check--method">
+                <label class="pub-filter-check pub-filter-check--method" title="{{ m }}">
                     <input type="checkbox" class="pub-filter-methods-input" data-methods="{{ m }}">
                     <span class="pub-filter-check-label">{{ m }}</span>
                     <span class="pub-filter-check-count" aria-hidden="true">{{ _method_counts[m] }}</span>

--- a/templates/pages/publications/publication-item.html
+++ b/templates/pages/publications/publication-item.html
@@ -52,8 +52,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300..600&family=Noto+Sans+TC:wght@300..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=17">
-    <link rel="stylesheet" href="/css/subpage.css?v=46">
+    <link rel="stylesheet" href="/css/general.css?v=19">
+    <link rel="stylesheet" href="/css/subpage.css?v=51">
     <link rel="stylesheet" href="/css/publication-item.css?v=8">
 
     <!-- js -->


### PR DESCRIPTION
## Summary
- Landing page heading hierarchy refresh — section H2s rename to "Recent Publications", "Featured Projects", "From the Group"; redundant H3s removed; surviving H3s restyled as uppercase eyebrow labels.
- Group Life click-through slider replaced with a continuous CSS marquee (3-copy seamless loop; hover / focus / touch-hold to pause; reduced-motion friendly).
- Publications filter UI standardized across all five facets (Year / Journal / Topic / Method / Type) — unified panel dimensions, single-line ellipsis labels with title-attr tooltips, fixed 2.5rem row height, journal sort by count desc.
- Polish: scroll-spy active nav, hero "About Us" CTA restored on phone, scroll cue restored on tablet, \`:focus-visible\` parity on linked H2s, news-article body capped at 75ch for readability.
- Data: add publisher link to Tam & Hsieh 2025 publication entry.

## Test plan
- [ ] Homepage at 375 / 768 / 1024 / 1280 / 1920 px — no horizontal scroll; hero "About Us" CTA visible on phone; scroll cue visible on tablet.
- [ ] Open the menu drawer and scroll the homepage — active item updates as each section's top crosses the trigger band; \`aria-current="location"\` is set on the active link.
- [ ] Group Life section — strip drifts continuously; hover / keyboard-focus / touch-hold pauses; reduced-motion stops animation; wrap-around (last photo adjacent to first) visible from frame zero.
- [ ] /publications/ — open each filter (Year, Journal, Topic, Method, Type); panel size, row height, and label rendering match across all five. Long journal names truncate with \`…\`; hover reveals the full name.
- [ ] /publications/ — journal list sorted count-desc (Transportation Research Part D and Journal of Taiwan Energy at the top).
- [ ] /news/<any item> — body prose wraps near 75ch on desktop, not edge-to-edge.
- [ ] Tab through a homepage section H2 (Publications / News / Members) — focus ring + underline-sweep affordance appears (focus-visible parity).
- [ ] Toggle \`prefers-reduced-motion: reduce\` — no new animations play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)