### PR TITLE
style(home): soften About-section inline link emphasis

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -834,34 +834,47 @@
             }
         }
 
-        /* Inline links inside the about article. With 5 links across 3
-           justified paragraphs the default browser underline reads as
-           visual noise, so we differentiate via color + weight at rest
-           and sweep an underline in on hover.
+        /* Inline links inside the about article.
+
+           Design notes (iterated twice):
+           1. First version used a lighter color + no underline at rest +
+              hover-only underline. Read as LESS prominent than body prose
+              — backwards.
+           2. Second version bumped weight to 600 and used a full-opacity
+              persistent 1px underline. Read as TOO marked-up — five
+              bolded, underlined phrases across three paragraphs felt loud.
+
+           Current: same dark teal as body, same weight as body, and a
+           subtle persistent underline (~35% opacity of currentColor)
+           that's just visible enough to say "this is a link" without
+           competing with the prose. On hover/focus, the underline
+           ramps to full color at 2px and the text shifts to the accent
+           blue — clear interactive feedback that builds on the rest
+           state instead of replacing a hidden one.
 
            The underline uses a background-image gradient (not
            text-decoration) so multi-word link phrases inside justified
            paragraphs render a continuous baseline — text-decoration
-           inherits the wordspace gaps that justification introduces.
-
-           The sweep direction and easing match `.publication-global-cta a`
-           in member.css so the site's hover-reveal language stays
-           consistent. */
+           inherits the word-space gaps that justification introduces. */
         & a {
-            color: color-mix(in srgb, var(--main-color) 55%, var(--main-color-2) 45%);
+            color: var(--main-color);
             font-weight: 500;
             text-decoration: none;
-            background-image: linear-gradient(currentColor, currentColor);
+            background-image: linear-gradient(
+                color-mix(in srgb, currentColor 35%, transparent),
+                color-mix(in srgb, currentColor 35%, transparent)
+            );
             background-position: 0 100%;
             background-repeat: no-repeat;
-            background-size: 0% 1px;
+            background-size: 100% 1px;
             padding-bottom: 0.08em;
-            transition: background-size 280ms cubic-bezier(0.16, 1, 0.3, 1),
+            transition: background-size 200ms cubic-bezier(0.16, 1, 0.3, 1),
                         color 200ms ease-out;
 
             &:hover,
             &:focus-visible {
-                background-size: 100% 1px;
+                background-image: linear-gradient(currentColor, currentColor);
+                background-size: 100% 2px;
                 color: var(--main-color-2);
             }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -58,7 +58,7 @@
 
     <!-- css -->
     <link rel="stylesheet" href="/css/general.css?v=17">
-    <link rel="stylesheet" href="/css/style.css?v=14">
+    <link rel="stylesheet" href="/css/style.css?v=16">
     <link rel="stylesheet" href="/css/subpage.css?v=46">
 
     <!-- js -->


### PR DESCRIPTION
## Summary
- About Us inline links were lighter than the body prose at rest — reversed the usual link affordance. A first pass overcorrected with weight 600 + full-opacity underline, which felt marked-up across five links and three justified paragraphs.
- Settles on: same color and weight as body + subtle persistent 1px underline at ~35% currentColor opacity. Hover/focus ramps the underline to full color at 2px and shifts text to the accent blue.

## Test plan
- [ ] Homepage \`/#about-us\` — five inline links (Department of Civil Engineering, NTU, I-Yun Lisa Hsieh, JOIN US, LinkedIn). At rest each phrase reads as part of the paragraph with a quiet underline; hover/keyboard-focus shows clear emphasis (thicker underline, accent-blue color).
- [ ] Tab through the links via keyboard — same emphasis as hover via \`:focus-visible\`.
- [ ] Confirm no regression elsewhere: the rule is scoped to \`.abt-section .abt-text & a\`.
- [ ] \`prefers-reduced-motion: reduce\` — transitions disabled (rule already in place above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)