### PR TITLE
fix(seo): sentence-aware meta descriptions + de-duplicate member fallbacks

### DIFF
--- a/lib/seo_helpers.py
+++ b/lib/seo_helpers.py
@@ -6,23 +6,29 @@ import re
 
 
 def generate_meta_description(primary, *fallback_sources, max_chars=160, min_chars=70):
-    """Return a description string ≤ max_chars, truncated at word boundary.
+    """Return a description string ≤ max_chars, truncated at a sentence
+    boundary when one falls in [min_chars, max_chars], otherwise at a word
+    boundary.
 
     `primary` (e.g. an author override) is used as-is when truthy after
     whitespace collapse. Otherwise, the first non-empty `fallback_sources`
-    entry is used. All inputs are whitespace-collapsed.
+    entry is used. Inputs are whitespace-collapsed and lightly
+    punctuation-normalised: an internal doubled '.' or '。' that arose from
+    naive concatenation collapses to a single terminator; legitimate
+    ellipses ('...' / '…') and decimals like '3.14' are preserved.
 
-    The min_chars argument is informational only — used by validate_seo()
-    to flag too-short descriptions, not enforced here.
+    `min_chars` bounds sentence-boundary back-off so we never drop below
+    validate_seo()'s warning floor; it stays advisory for callers (build.py
+    logs a warning at the same threshold).
     """
     candidates = [primary, *fallback_sources]
     for raw in candidates:
         if not raw:
             continue
-        cleaned = _collapse_whitespace(raw)
+        cleaned = _normalize_punctuation(_collapse_whitespace(raw))
         if not cleaned:
             continue
-        return _truncate_at_word_boundary(cleaned, max_chars)
+        return _truncate_at_word_boundary(cleaned, max_chars, min_chars)
     return ""
 
 
@@ -30,11 +36,77 @@ def _collapse_whitespace(s):
     return re.sub(r"\s+", " ", s).strip()
 
 
-def _truncate_at_word_boundary(s, max_chars):
+# Collapse an internal doubled sentence terminator that arose from naive
+# concatenation ('University.' + '. Research…' → 'University.. Research…').
+# Negative look-arounds preserve legitimate ellipses ('...' has 3 dots —
+# left alone) and CJK ellipsis runs.
+_DOUBLED_DOT_RE = re.compile(r"(?<!\.)\.{2}(?!\.)")
+_DOUBLED_CJK_DOT_RE = re.compile(r"(?<!。)。{2}(?!。)")
+
+
+def _normalize_punctuation(s):
+    if not s:
+        return s
+    s = _DOUBLED_DOT_RE.sub(".", s)
+    s = _DOUBLED_CJK_DOT_RE.sub("。", s)
+    return s
+
+
+_CJK_TERMINATORS = ("。", "！", "？")
+_ASCII_TERMINATORS = (".", "!", "?")
+
+# Tokens that commonly precede a '.' inside academic prose; the '.' after
+# these is NOT a sentence boundary. Matched case-insensitive against the
+# token between the prior whitespace and the '.'.
+_ABBREVIATIONS = frozenset({
+    "dr", "mr", "mrs", "ms", "st", "jr", "sr",
+    "ph.d", "m.d", "b.s", "m.s", "b.a", "m.a",
+    "i.e", "e.g", "etc", "vs", "cf", "approx", "ca",
+    "no", "vol", "fig", "eq", "pp", "ch", "sec", "p",
+    "co", "inc", "ltd", "et", "al",
+})
+
+
+def _is_sentence_boundary(s, i):
+    """True iff s[i] terminates a sentence in context.
+
+    CJK terminators ('。', '！', '？') are unambiguous. ASCII terminators
+    ('.', '!', '?') are accepted only when followed by whitespace or
+    end-of-string AND the token before the '.' is not in _ABBREVIATIONS
+    and not a single capital letter (an initial like 'I.', 'J.').
+    """
+    ch = s[i]
+    if ch in _CJK_TERMINATORS:
+        return True
+    if ch not in _ASCII_TERMINATORS:
+        return False
+    if i + 1 < len(s) and not s[i + 1].isspace():
+        return False
+    if ch == ".":
+        # Walk back to the prior whitespace; token = chars between space and '.'.
+        j = i - 1
+        while j >= 0 and not s[j].isspace():
+            j -= 1
+        token = s[j + 1:i].lower()
+        if token in _ABBREVIATIONS:
+            return False
+        # Single capital letter before '.' = initial (I., J., A.).
+        if len(token) == 1 and s[i - 1].isupper():
+            return False
+    return True
+
+
+def _truncate_at_word_boundary(s, max_chars, min_chars=0):
     if len(s) <= max_chars:
         return s
     cut = s[:max_chars]
-    # Walk back to last whitespace so we don't cut mid-word
+    # 1) Prefer the latest sentence boundary in [min_chars, max_chars] so the
+    #    snippet reads as a finished thought; the terminator is retained.
+    floor = max(min_chars - 1, 0)
+    for i in range(len(cut) - 1, floor, -1):
+        if _is_sentence_boundary(cut, i):
+            return cut[: i + 1].rstrip(" ,;:")
+    # 2) Fall back to the prior word-boundary behaviour: last ASCII space.
     last_space = cut.rfind(" ")
     if last_space > 0:
         return cut[:last_space].rstrip(" ,;:.")

--- a/templates/pages/member/member.html
+++ b/templates/pages/member/member.html
@@ -19,15 +19,31 @@
       {% endfor %}
     {% endif %}
 
-    {# Compose name-led prefix (uses position when present, otherwise an E3 Center role descriptor).
-       Includes Chinese name for Taiwan-region SEO (matches both English and Chinese queries). #}
-    {% set _role = member.get('position') or 'researcher at E3 Center, NTU' %}
+    {# Compose name-led prefix. Trailing sentence-terminators on the role are
+       stripped so the literal '. Research interests:' / '. <about>' appended
+       below cannot produce a doubled period (seo_helpers also collapses '..'
+       defensively, but stripping here keeps the composed string clean). #}
+    {% set _role_raw = (member.get('position') or 'researcher at E3 Center, NTU') | trim %}
+    {% set _role = _role_raw.rstrip('. ,;:!?') %}
     {% set _name_prefix = _bilingual_name ~ ', ' ~ _role %}
 
     {# Fallbacks ordered by quality #}
     {% set _auto_desc_a = (_name_prefix ~ '. Research interests: ' ~ _interest) if _interest else '' %}
     {% set _auto_desc_b = (_name_prefix ~ '. ' ~ _ns.about_first) if _ns.about_first else '' %}
-    {% set _auto_desc_c = _bilingual_name ~ ' — member of E3 Center, National Taiwan University.' %}
+    {# Fallback C: a role-bearing line is distinct per-member (replaces the
+       prior 23-page-duplicate generic sentence). When the role-only string
+       is too short to clear validate_seo's 70-char floor, tail-pad with the
+       E3 Center tagline so the snippet still lands in the [70, 160] window. #}
+    {% if member.get('position') %}
+      {% set _role_only = _name_prefix ~ '.' %}
+      {% if (_role_only | length) >= 70 %}
+        {% set _auto_desc_c = _role_only %}
+      {% else %}
+        {% set _auto_desc_c = _role_only ~ ' E3 Center · Energy × Economics × Environment, National Taiwan University.' %}
+      {% endif %}
+    {% else %}
+      {% set _auto_desc_c = _bilingual_name ~ ' — member of E3 Center, National Taiwan University.' %}
+    {% endif %}
     {% set _meta_desc = seo_meta_description(member.get('metaDescription'), _auto_desc_a, _auto_desc_b, _auto_desc_c) %}
     <meta name="description" content="{{ _meta_desc }}">
     {% set _kw_parts = [member.get('engName'), member.get('chiName'), member.get('chiNameEng'), member.get('position')] %}


### PR DESCRIPTION
## Summary
- **Bug A fix** — member pages whose `position` ended in '.' produced `'University.. Research interests:'` (visible doubled period in SERP snippets). Also, the truncation helper only walked back to the last ASCII space, producing dangling-conjunction endings like `'…Climate and'`, `'…Vehicle-to-Building'`, `'…Sustainable'`.
- **Bug B fix** — 23 of 37 member pages emitted a byte-identical fallback `'<Name> — member of E3 Center, National Taiwan University.'`, a duplicate-meta-description anti-pattern.
- Both bugs flagged in the 2026-05-13 SEO 3mo analysis; still byte-identical on source.

## Changes
**lib/seo_helpers.py**
- `_truncate_at_word_boundary` now prefers the latest sentence boundary in `[min_chars, max_chars]`; falls back to the prior word-boundary cut when no boundary sits in band (so callers with no terminators — pure CJK runs, short prose — keep working).
- Recognises `.`, `!`, `?`, `。`, `！`, `？`. For ASCII `.` requires trailing whitespace/EOS (so `3.14` doesn't mis-cut) and rejects single-capital initials + an abbreviation deny-list (`Dr`, `Ph.D`, `M.D`, `B.S`, `M.S`, `i.e`, `e.g`, `etc`, `vs`, `cf`, `Fig`, `No`, `Vol`, `Inc`, `Ltd`, `et al`, …) so academic prose doesn't end on `Ph.D.` or `i.e.`.
- New `_normalize_punctuation` collapses internal `..` / `。。` arising from naive concatenation, with negative-lookarounds preserving legitimate ellipses (`...` / `…`) and decimals (`3.14`).

**templates/pages/member/member.html**
- Strips trailing `'. ,;:!?'` from the role before composing `_name_prefix`, defence-in-depth against any future position field with a terminator.
- Fallback C: when `member.position` is present, derive from `_name_prefix` (encodes Name/Role/Department/Affiliation) instead of the canned 23-page-duplicate string. Tail-pad with `' E3 Center · Energy × Economics × Environment, National Taiwan University.'` when the role-only string is under 70 chars so brief positions still clear `validate_seo`'s SEO floor.

## Verification
| Page | Before | After | Notes |
|------|--------|-------|-------|
| chenghsiangshei | 157 | 97 | Bug A: `..Climate and` → clean `University.` |
| jianhernyeoh | 157 | 87 | Bug A: same pattern |
| hungjuilin | 159 | 106 | Bug A: `Ph.D.` correctly NOT cut as boundary |
| chihyilu | 159 | 107 | Bug A: same — sentence boundary at University. |
| yugoimoto | 66 | 106 | Bug B: tail-pad lifts above floor |
| chunhaohuang | 69 | 134 | Bug B: same |
| chihyacheng | 76 | 141 | Bug B: same |
| iyunlisahsieh | 158 | 158 | Control: explicit metaDescription, unchanged |

37/37 member pages, 5/5 news pages, 40/40 publication pages within [70, 160] post-fix. Zero `validate_seo` "too short" warnings on member pages (was 6+).

## Side-effect on publication pages
21 of 40 publication abstracts now truncate at the latest sentence boundary instead of mid-phrase — shorter but cleaner snippets:
- `2023-vehicle-fleet-electrification-scooters`: 157 → 77 chars, ending at `'…pathway toward net-zero emissions.'` instead of `'…the existing timeline for banning internal combustion'`.

All stay ≥ 70. If preserving publication snippet length matters more than sentence completion, pass `min_chars=120` from `templates/pages/publications/publication-item.html` later — the helper signature already supports per-caller overrides (default stays at 70).

## Process
Designed via Workflow with parallel investigation (bug surface + blast radius) → single-agent design → 2-agent adversarial verification (correctness + downstream regression). V1 design refuted (would have manufactured 3 new "too short" warnings); v2 fixes the floor regression and the abbreviation guard the v1 verifier flagged.

## Test plan
- [ ] `python build.py` completes cleanly
- [ ] Compare meta-desc range across `docs/{members,publications,news,projects}/*/index.html` — all in [70, 160]
- [ ] Spot-check `docs/members/{chenghsiangshei,jianhernyeoh,anchingchung,yugoimoto,iyunlisahsieh}/index.html` for clean rendering
- [ ] Verify `iyunlisahsieh` (the control with explicit `metaDescription`) is byte-identical to pre-fix
- [ ] Next Google crawl: duplicate-meta-description warnings on the previously-affected 23 member URLs should clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)