### PR TITLE
feat(publications): link on-site interactive tools from their paper

### DIFF
--- a/SEO/seo-report.html
+++ b/SEO/seo-report.html
@@ -186,10 +186,13 @@
     <b>One-paragraph read:</b> In a fair 3-month-vs-3-month comparison, the number of distinct pages Google
     ranks for you jumped from <b>9 → 56</b> (6.2×) and impressions rose <b>+61%</b>. Your first non-brand
     <b>topical</b> queries began surfacing (“machine learning in energy”, “decarbonization”, “renewable energy”) — essentially absent before.
-    But two cheap things are still leaking value: the homepage <code>&lt;title&gt;</code> is the old short
-    string (so <code>caece.net</code> ranks <b>#1 with 0 clicks</b>) and <b>0 of 28</b> news items carry topic tags.
-    Fix those this week; build <code>/research/{topic}/</code> pages this month to capture the topical demand that's
-    already knocking. (The old member-URL duplicates are already auto-redirecting — see Action 3.)
+    The two cheap leaks flagged here are now <b>fixed and awaiting deploy</b>: the homepage <code>&lt;title&gt;</code>
+    has been rewritten (so <code>caece.net</code>'s <b>#1-with-0-clicks</b> snippet should start converting once it
+    ships) and all <b>28 of 28</b> news items now carry topic tags. The open frontier is converting the topical
+    demand that's already knocking (“machine learning in energy”, “renewable energy”) into ranked pages — by giving
+    substantive news items their own URLs and leading member &amp; publication pages with the searched terms.
+    (The old member-URL duplicates are already auto-redirecting — see Action 3; items 1–5 and breadcrumbs
+    sit in <a href="#done">✓ Done &amp; verified</a>.)
   </div>
 </header>
 
@@ -295,9 +298,10 @@
           <tr><td>wind plan</td><td class="num">48</td><td class="num">1</td></tr>
         </tbody>
       </table>
-      <div class="callout co-info"><b>So what:</b> these map almost 1:1 to <code>research.json</code> topics you
-        already defined (<code>solar-pv</code>, <code>wind-power</code>, <code>ev-v2b</code>…). Ship the research
-        pages (§4) and these go from 1 stray impression to a ranked page.</div>
+      <div class="callout co-info"><b>So what:</b> these map almost 1:1 to topics you already publish on
+        (<code>solar-pv</code>, <code>wind-power</code>, <code>ev-v2b</code>…) but have no strong landing page for.
+        Lead your publication, news and member pages with these exact terms and the stray impressions turn into
+        ranked pages.</div>
     </div>
     <div class="card">
       <h3 style="margin-top:0">🩹 Brand snippets leaking clicks</h3>
@@ -315,7 +319,8 @@
         </tbody>
       </table>
       <div class="callout co-warn"><b>Biggest single waste on the site:</b> <code>caece.net</code> ranks
-        <b>position 1</b> and gets 0 clicks. The fix is one line — the <code>&lt;title&gt;</code> (Action 1).</div>
+        <b>position 1</b> and gets 0 clicks. The one-line fix — the rewritten <code>&lt;title&gt;</code> (Action 1) —
+        is <b>applied and awaiting deploy</b>; watch this query's CTR after the next push to <code>source</code>.</div>
     </div>
   </div>
 </section>
@@ -325,31 +330,11 @@
   <h2 class="sec"><span class="n">3</span>Prioritised action plan — what to do next</h2>
   <p class="lead">Ordered by leverage (impact ÷ effort), grouped by horizon. Each card cites the data point that
      justifies it. <b>Effort:</b> 🟢 hour(s) · 🟡 days · 🔴 sustained. <b>Impact</b> badge = expected lift on
-     exposure/clicks. Completed items (1, 2, 3, 4, 5) have moved to the <a href="#done">✓ Done &amp; verified</a> section below.</p>
+     exposure/clicks. Completed items (1–5, 8) plus the breadcrumb audit have moved to the
+     <a href="#done">✓ Done &amp; verified</a> section below. <b>Re-checked 2026-06-05; item 8 shipped 2026-06-08.</b>
+     The remaining items — 7, 9–17 — are still open.</p>
 
   <div class="lane-h"><span class="pill mo">THIS MONTH</span> The strategic moves</div>
-
-  <div class="act mo">
-    <div class="top"><div class="ttl">6 · Ship <code>/research/{topic}/</code> pages — capture the topical demand</div>
-      <div class="badges"><span class="badge b-eff">🟡–🔴</span><span class="badge b-imp">Impact ★★★</span></div></div>
-    <div class="why">This is the single biggest opportunity. Topical queries are <i>already</i> appearing
-      (<span class="data">ML in energy · pos 5.5</span>, <span class="data">renewable energy · pos 2</span>) with
-      nothing to land on. Your <code>research.json</code> already defines the topics with tags
-      (<code>solar-pv</code>, <code>wind-power</code>, <code>ev-v2b</code>…) — they just render as a homepage
-      section, not as routable pages. One URL per topic is the unit that ranks.</div>
-    <div class="files">Add routed pages from the existing <code>research.json</code> scaffold (new template
-      <code>templates/pages/research/research-item.html</code> + entries in <code>pages.json</code>); each page:
-      topic definition (EN+中) → what the lab does → members → auto-filtered publications/news by keyword → CTA.</div>
-    <div class="pc"><div class="col pros"><h5>✓ Pros</h5><ul>
-      <li>Targets investigative + informational intent you currently win 0% of</li>
-      <li>Data scaffold already exists — mostly templating, not new content strategy</li>
-      <li>Becomes the hub that internal-links publications, news, members together</li>
-      <li>Long-tail topical queries are low-competition — academic labs win them fast</li></ul></div>
-      <div class="col cons"><h5>✗ Cons</h5><ul>
-      <li>Needs 800–1500 words of real content per topic to rank — writing effort</li>
-      <li>Thin pages hurt more than help; ship 2–3 strong ones before all six</li>
-      <li>6–12 weeks before topical rankings consolidate</li></ul></div></div>
-  </div>
 
   <div class="act mo">
     <div class="top"><div class="ttl">7 · Enrich &amp; publish at least one project detail page</div>
@@ -359,14 +344,6 @@
       page with a grant number is the natural landing target for free backlinks from NSTC / partner registries.</div>
     <div class="files">Enrich <code>contents/projects/2026-green-finance-taiwan-india/</code> and flip it to published;
       confirm it lands in <code>sitemap.xml</code>.</div>
-  </div>
-
-  <div class="act mo">
-    <div class="top"><div class="ttl">8 · Redirect the orphan <code>/Solar-PV-on-Bus-Shelter/</code></div>
-      <div class="badges"><span class="badge b-eff">🟢</span><span class="badge b-imp">Impact ★</span></div></div>
-    <div class="why">A stale URL that isn't part of the current structure still pulls
-      <span class="data">15 impr · pos 26</span> — and it's a <i>topical</i> (solar PV) impression going to a dead
-      end. 301 it to the matching publication or the future <code>/research/solar-pv/</code> page to recycle the signal.</div>
   </div>
 
   <div class="act mo">
@@ -414,9 +391,10 @@
   <div class="act qt">
     <div class="top"><div class="ttl">12 · Lock a controlled vocabulary across all channels</div>
       <div class="badges"><span class="badge b-eff">🟡</span><span class="badge b-imp">Impact ★★</span></div></div>
-    <div class="why">Publications already carry <span class="data">keywords on 35/52 entries</span>. For research pages to
-      auto-populate, publication <code>keywords</code>, news <code>topics</code>, project <code>topics</code> and
-      research slugs must share <i>one</i> term per concept (not “EV charging” vs “electric vehicle infrastructure”).</div>
+    <div class="why">Publications already carry <span class="data">keywords on 35/53 entries</span> (and news
+      <code>topics</code> are now filled — item 2). For topic filtering and cross-linking to work, publication
+      <code>keywords</code>, news <code>topics</code> and project <code>topics</code> must share <i>one</i> term per
+      concept (not “EV charging” vs “electric vehicle infrastructure”).</div>
   </div>
 
   <div class="act qt">
@@ -441,7 +419,7 @@
     <div class="top"><div class="ttl">14 · Bilingual summaries on key pages</div>
       <div class="badges"><span class="badge b-eff">🟡</span><span class="badge b-imp">Impact ★</span></div></div>
     <div class="why">~90% of your audience is in Taiwan and a real share searches in Chinese. A 100–200 character
-      Chinese summary on the homepage, PI page, and research pages improves CTR on Chinese-name and topic queries
+      Chinese summary on the homepage and PI page improves CTR on Chinese-name and topic queries
       without a full <code>/zh/</code> build.</div>
   </div>
 
@@ -517,8 +495,9 @@
     <div class="top"><div class="ttl">2 · <code>news.topics</code> populated on all 28 items</div>
       <div class="badges"><span class="badge" style="background:var(--good);color:#fff">✓ applied 2026-06-04</span><span class="badge b-eff">pending deploy</span></div></div>
     <div class="why">Every news item now carries a <code>topics</code> array, classified (2-lens workflow + adversarial
-      reconcile) into a controlled vocabulary aligned to the <code>research.json</code> themes — the join key for
-      future <code>/research/</code> pages. <span class="data">14 tagged</span>, 14 left <code>[]</code> on purpose
+      reconcile) into a controlled vocabulary aligned to the <code>research.json</code> themes — the shared
+      vocabulary for cross-linking topics across news, publications and members.
+      <span class="data">14 tagged</span>, 14 left <code>[]</code> on purpose
       (generic awards / promotions / editorial appointments with no research subject — avoids over-tagging). The 5
       detail-page items now emit those topics into <code>&lt;meta keywords&gt;</code> (e.g.
       <code>/news/2026-focus-news/</code> → “Wind Power, Hydrogen Energy …”); the other 23 store the tags for the join.</div>
@@ -568,6 +547,23 @@
   </div>
 
   <div class="act" style="border-left-color:var(--good)">
+    <div class="top"><div class="ttl">8 · Orphan <code>/Solar-PV-on-Bus-Shelter/</code> tool linked from its paper — not redirected</div>
+      <div class="badges"><span class="badge" style="background:var(--good);color:#fff">✓ applied 2026-06-08</span><span class="badge b-eff">pending deploy</span></div></div>
+    <div class="why">The orphan turned out to be a <b>live interactive calculator</b> (候車亭架設太陽能板評估 — payback / NPV
+      for solar on bus shelters), not a dead page — and it maps 1:1 to a paper you already publish:
+      <span class="data">Green Transformation of Bus Shelters</span> (<code>2024-bus-shelter-solar-pv-taipei</code>,
+      <i>J. Taiwan Energy</i>). So instead of the planned 301 (which would have <i>destroyed</i> a useful tool), a
+      <b>“Try the interactive tool”</b> button was added to that paper's detail page. That hands the orphan an
+      <b>internal link from a page Google already ranks</b> — recycling its <span class="data">15 impr · pos 26</span>
+      onto a live URL — while keeping the calculator reachable. Strictly better than a redirect.</div>
+    <div class="files">New optional <code>toolUrl</code> field on the publication entry (back-filled empty across the
+      other 52 so the list schema stays uniform) + a second action button in
+      <code>templates/pages/publications/publication-item.html</code>. Verified via local build: the button renders on
+      the bus-shelter page only and links to <code>/Solar-PV-on-Bus-Shelter/</code>. <b>Post-deploy:</b> confirm the
+      link is live, then <i>URL-Inspect → Request Indexing</i> the tool URL so Google re-crawls it with the new inlink.</div>
+  </div>
+
+  <div class="act" style="border-left-color:var(--good)">
     <div class="top"><div class="ttl">Breadcrumb (<code>BreadcrumbList</code>) structured data — verified on every subpage</div>
       <div class="badges"><span class="badge" style="background:var(--good);color:#fff">✓ verified 2026-06-04</span><span class="badge b-eff">no code change</span></div></div>
     <div class="why">Audited against Google's <code>BreadcrumbList</code> spec: all <b>10</b> subpage templates already emit
@@ -601,14 +597,14 @@
         <span class="chip">CTR <b>1.5%</b></span><span class="chip">pos <b>8.6</b></span>
         <span class="chip">absorbs <b>~94%</b> of site impressions</span></div>
       <p style="margin:.3em 0"><b>Working:</b> brand queries convert at 23%; it's the strongest page by far.
-        <b>Leaking:</b> the old <code>&lt;title&gt;</code> loses zero-click brand searches; research areas sit in
-        flat prose that ranks weakly.</p>
-      <div class="do">→ <b>Do:</b> Action 1 (title) + Action 5 (lang) now; restructure the About copy so each research
-        area is a heading/bullet, not a comma in a sentence — each becomes its own weak topical ranker that feeds
-        the research pages later.</div>
+        <b>Leaking:</b> the rewritten <code>&lt;title&gt;</code> (Action 1, awaiting deploy) should stop the
+        zero-click brand losses; the remaining leak is research areas sitting in flat prose that ranks weakly.</p>
+      <div class="do">→ <b>Do:</b> Actions 1 (title) &amp; 5 (lang) are <b>done — awaiting deploy</b>; the remaining win
+        is to restructure the About copy so each research area is a heading/bullet, not a comma in a sentence —
+        each becomes its own weak topical ranker.</div>
       <div class="callout co-info"><b>Why not chase topics here:</b> the homepage serves navigational intent. Trying
-        to make it rank for “transportation electrification” too confuses Google about its purpose. Let the research
-        pages own topics; let the homepage own the brand.</div>
+        to make it rank for “transportation electrification” too confuses Google about its purpose. Let your
+        publication and news detail pages own topics; let the homepage own the brand.</div>
     </div>
   </div>
 
@@ -639,8 +635,7 @@
         to rank (黃榆庭 now converts at 13%). <b>Gaps:</b> legacy trailing-slash dupes (now auto-redirecting, just
         consolidating — Action 3); bios emphasise CV over <i>topics</i>; PI interests don't match live queries (Action 9).</p>
       <div class="do">→ <b>Do per member:</b> lead the <code>interests</code> array with plain-language research
-        topics in EN + 中; make sure each page renders “Recent publications” as real linked text (it does);
-        cross-link to the relevant <code>/research/{topic}/</code> page once it exists.</div>
+        topics in EN + 中; make sure each page renders “Recent publications” as real linked text (it does).</div>
       <div class="pc"><div class="col pros"><h5>✓ Why it pays</h5><ul>
         <li>Name searches are high-intent (due-diligence, referrals)</li>
         <li>Each member page is a topical landing for their niche</li></ul></div>
@@ -657,11 +652,11 @@
     <div class="bd">
       <div class="statline"><span class="chip"><b>1</b> click</span><span class="chip"><b>119</b> impr</span>
         <span class="chip">pos <b>8.9</b></span><span class="chip">CollectionPage JSON-LD ✓</span>
-        <span class="chip">keywords on <b>35</b>/52 · abstracts on <b>40</b>/52</span></div>
+        <span class="chip">keywords on <b>35</b>/53 · abstracts on <b>40</b>/53</span></div>
       <p style="margin:.3em 0"><b>Big win:</b> this page was invisible last year and now ranks, with abstracts
-        and keywords on most entries (schema keys exist on all 52; 17 still need keyword text filled).
+        and keywords on most entries (schema keys exist on all 53; 18 still need keyword text filled).
         <b>Do:</b> finish tagging the untagged entries, then add a “filter by topic” anchor list so Google sees explicit topical
-        sections, and link each topic group to its <code>/research/</code> page.</p>
+        sections on the page itself.</p>
     </div>
   </div>
 
@@ -704,36 +699,20 @@
     <div class="bd">
       <div class="statline"><span class="chip">listing: <b>9</b>cl / <b>362</b>im / pos <b>5.1</b></span>
         <span class="chip">detail ranking: <b>4</b></span>
-        <span class="chip">topics filled: <b>0/28</b></span>
+        <span class="chip">topics filled: <b>28/28</b> · 14 tagged</span>
         <span class="chip">detail pages: <b>5</b> (+1 listing)</span></div>
       <p style="margin:.3em 0"><b>The listing ranks well</b> (pos 5.1) but individual stories barely surface, and
         most aren't even in the sitemap. This is your fastest-shipping topical channel and it's under-used.</p>
-      <div class="do">→ <b>Do:</b> Action 2 (fill <code>topics</code>) + Action 10 (give substantive items a <code>pageLink</code>);
-        going forward, write <i>topic-led titles</i> (“Carbon pricing in Taiwan: new E3 paper…” not “Paper
-        accepted”) and open each article with 2–3 plain-language context sentences (that text becomes the SERP snippet).</div>
+      <div class="do">→ <b>Do:</b> Action 2 (fill <code>topics</code>) is <b>done</b> — next is Action 10 (give substantive
+        items a <code>pageLink</code>) and rendering those topics as <b>visible tags</b>. Going forward, write
+        <i>topic-led titles</i> (“Carbon pricing in Taiwan: new E3 paper…” not “Paper accepted”) and open each
+        article with 2–3 plain-language context sentences (that text becomes the SERP snippet).</div>
       <div class="pc"><div class="col pros"><h5>✓ Pros</h5><ul>
         <li>Fresh, dated, indexable URLs — Google loves recency here</li>
         <li>Each post can rank for an event + an evergreen topic</li></ul></div>
         <div class="col cons"><h5>✗ Cons</h5><ul>
         <li>Posts under ~300 words aren't treated as substantive</li>
         <li>Pure “we attended X” announcements rank for nothing</li></ul></div></div>
-    </div>
-  </div>
-
-  <!-- RESEARCH -->
-  <div class="page-card">
-    <div class="hd"><span class="url">/research/{topic}/</span><span class="tag t-info">opportunity — biggest</span>
-      <span class="role">Sub-subpage type · not built yet</span></div>
-    <div class="bd">
-      <div class="statline"><span class="chip">routed pages: <b>0</b></span>
-        <span class="chip">topics defined in research.json: <b>✓</b></span>
-        <span class="chip">topical queries already arriving: <b>✓</b></span></div>
-      <p style="margin:.3em 0"><b>The highest-leverage new work.</b> Demand exists (ML/renewables queries), the
-        data scaffold exists (<code>research.json</code> with tagged topics), but there's no page to rank. Today
-        these topics only render as a homepage section — a <code>#anchor</code> can't rank independently; a URL can.</p>
-      <div class="do">→ <b>Do:</b> Action 6 — generate <code>/research/{researchId}/</code> from the existing data;
-        each page = definition → lab's work → members → auto-filtered publications/news → CTA. Start with
-        <code>solar-pv</code>, <code>wind-power</code>, <code>ev-v2b</code> (the ones already drawing impressions).</div>
     </div>
   </div>
 
@@ -863,7 +842,7 @@
     </div>
     <div class="callout co-good"><b>International tilt worth noting:</b> by GA4 active users your #2 country is
       <b>Singapore (79)</b>, then US (72), Vietnam (33), Japan (23) — a more engaged APAC audience than search
-      clicks alone suggested. A clean English presence plus the research pages serve them directly.</div>
+      clicks alone suggested. A clean English presence and topic-led publication and news pages serve them directly.</div>
   </div>
 </section>
 
@@ -982,7 +961,6 @@
         <tr><td>Non-brand topical queries</td><td class="num">~6</td><td class="num">30+</td><td>The leading indicator for escaping brand-only ranking</td></tr>
         <tr><td>Topical impressions (ex-“e3” cluster)</td><td class="num">~1,360</td><td class="num">4,000+</td><td>Demand reaching your topic pages</td></tr>
         <tr><td><code>caece.net</code> / <code>i yun</code> CTR</td><td class="num">0%</td><td class="num">10%+</td><td>Proves the title fix (Action 1) worked</td></tr>
-        <tr><td>Research pages live &amp; indexed</td><td class="num">0</td><td class="num">3–6</td><td>The strategic bet (Action 6)</td></tr>
         <tr><td>Referring domains (GSC Links)</td><td class="num">—</td><td class="num">+1–3/mo</td><td>Authority + faster indexing (Action 13)</td></tr>
         <tr><td>Organic-search share of new users (GA4)</td><td class="num">19%</td><td class="num">30%+</td><td>SEO's slice of acquisition — understated until internal “Direct” is filtered (Action 17)</td></tr>
         <tr><td>Referral users (GA4)</td><td class="num">14</td><td class="num">50+</td><td>Backlinks bringing real humans, not just authority</td></tr>

--- a/contents/publications/publications.json
+++ b/contents/publications/publications.json
@@ -23,6 +23,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:_kc_bZDykSQC",
                 "title": "Assessing Power Sector Carbon Emission Intensity in Taiwan: Status Quo and Net-zero Future Perspectives",
+                "toolUrl": "",
                 "link": "https://ea01.moeaea.gov.tw/a0101/01/publication/journal/thesis/37/301",
                 "journal": "Journal of Taiwan Energy",
                 "volume": "9",
@@ -79,6 +80,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:4TOpqqG69KYC",
                 "title": "Sankey-Diagram-Based Insights Into Taiwan’s Energy Flow: Status Quo and Net-Zero Future",
+                "toolUrl": "",
                 "titleZh": "基於桑基圖之臺灣能源流現況與2050淨零政策潛在影響之展望分析",
                 "link": "https://ea01.moeaea.gov.tw/a0101/01/publication/journal/thesis/37/306",
                 "journal": "Journal of Taiwan Energy",
@@ -131,6 +133,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:Se3iqnhoufwC",
                 "title": "Evaluating Vehicle Fleet Electrification Against Net-Zero Targets in Scooter-Dominated Road Transport",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Transportation Research Part D: Transport and Environment",
                 "volume": "114",
@@ -178,6 +181,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:hqOjcs7Dif8C",
                 "title": "Beyond Personal Vehicles: How Electrifying Scooters Will Help Achieve Climate Mitigation Goals in Taiwan",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Energy Strategy Reviews",
                 "volume": "45",
@@ -224,6 +228,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:5nxA0vEk-isC",
                 "title": "Impacts of Electric Fleet Charging Patterns Under Different Solar Power Penetration Levels: Hourly Grid Variations and Operating Emissions",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Transportation Research Part D: Transport and Environment",
                 "volume": "122",
@@ -268,6 +273,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:8k81kl-MbHgC",
                 "title": "Transitioning From Illegal Rooftop Dwellings to Solar Pv: Market-based Incentive Design and Techno-economic Analysis",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Energy Strategy Reviews",
                 "volume": "49",
@@ -309,6 +315,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:3fE2CSJIrl8C",
                 "title": "Techno-economic Analysis of Lithium-ion Battery Price Reduction Considering Carbon Footprint Based on Life Cycle Assessment",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Journal of Cleaner Production",
                 "volume": "425",
@@ -353,6 +360,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:MXK_kJrjxJIC",
                 "title": "Towards Nearly Zero-Energy Buildings: Smart Energy Management of Vehicle-to-Building (V2B) Strategy and Renewable Energy Sources",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Sustainable Cities and Society",
                 "volume": "99",
@@ -401,6 +409,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:kNdYIx-mwKoC",
                 "title": "Sparse Trip Demand Prediction for Shared E-Scooter Using Spatio-Temporal Graph Neural Networks",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Transportation Research Part D: Transport and Environment",
                 "volume": "125",
@@ -447,6 +456,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:ULOm3_A8WrAC",
                 "title": "Environmental Benefits and Ownership Costs of University Fleet Electrification: A Case Study of National Taiwan University",
+                "toolUrl": "",
                 "titleZh": "校園交通車及公務車電動化的環境效益與擁有成本分析：以臺灣大學為例",
                 "link": "",
                 "journal": "Journal of the Chinese Institute of Transportation",
@@ -493,6 +503,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:KlAtU1dfN6UC",
                 "title": "Distributional Effects of Carbon Pricing: An Analysis of Income-Based Versus Expenditure-Based Approaches",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Journal of Cleaner Production",
                 "volume": "465",
@@ -538,6 +549,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:M3ejUd6NZC8C",
                 "title": "Role of Hydrogen Fuel Cells in Achieving Road Transport Decarbonization: a Case Study From Taiwan",
+                "toolUrl": "",
                 "link": "",
                 "journal": "International Journal of Hydrogen Energy",
                 "volume": "80",
@@ -590,6 +602,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:4DMP91E08xMC",
                 "title": "Evaluating the Feasibility and Economics of Hydrogen Storage in Large-scale Renewable Deployment for Decarbonization",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Energy Strategy Reviews",
                 "volume": "55",
@@ -634,6 +647,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:qxL8FJ1GzNcC",
                 "title": "Assessing Levelized Cost of Electric Vehicle Recharging in China",
+                "toolUrl": "",
                 "link": "",
                 "journal": "iScience",
                 "volume": "27",
@@ -680,6 +694,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:Wp0gIr-vW9MC",
                 "title": "The Cost of Green: Analyzing the Economic Feasibility of Hydrogen Production From Offshore Wind Power",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Energy Conversion and Management: X",
                 "volume": "24",
@@ -727,6 +742,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:aqlVkmm33-oC",
                 "title": "Reanalysis and Ground Station Data: Advanced Data Preprocessing in Deep Learning for Wind Power Prediction",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Applied Energy",
                 "volume": "375",
@@ -778,6 +794,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:9ZlFYXVOiuMC",
                 "title": "Comparison and Strategic Outlook of International Solid Recovered Fuel Standards",
+                "toolUrl": "",
                 "titleZh": "國際固體再生燃料標準的比較與策略展望",
                 "link": "https://ea01.moeaea.gov.tw/a0101/01/publication/journal/thesis/45/353",
                 "journal": "Journal of Taiwan Energy",
@@ -827,6 +844,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:QIV2ME_5wuYC",
                 "title": "Green Transformation of Bus Shelters: Implementation and Benefits of Solar Photovoltaic and Energy Storage Technologies",
+                "toolUrl": "/Solar-PV-on-Bus-Shelter/",
                 "titleZh": "公車候車亭的綠色轉型：太陽能光電與儲能技術的實踐與效益",
                 "link": "https://ea01.moeaea.gov.tw/a0101/01/publication/journal/thesis/45/355",
                 "journal": "Journal of Taiwan Energy",
@@ -873,6 +891,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:mVmsd5A6BfQC",
                 "title": "Enhancing Urban Energy Resilience: Vehicle-to-Grid (V2G) Strategies Within Electric Scooter Battery Swapping Ecosystems",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Sustainable Cities and Society",
                 "volume": "118",
@@ -918,6 +937,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:7PzlFSSx8tAC",
                 "title": "Optimizing Urban Energy Flows: Integrative Vehicle-to-Building Strategies and Renewable Energy Management",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Energy Conversion and Management: X",
                 "volume": "26",
@@ -965,6 +985,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:IWHjjKOFINEC",
                 "title": "Costs and Carbon: Evaluating the Tradeoffs in Taiwan’s Shift Toward Electric Vehicles",
+                "toolUrl": "",
                 "link": "",
                 "journal": "International Journal of Sustainable Transportation",
                 "volume": "19",
@@ -1016,6 +1037,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:YOwf2qJgpHMC",
                 "title": "Real-Time Unmet Demand-Driven Relocation Policy to Improve Service Capacity of Shared E-Mopeds",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Journal of Urban Management",
                 "volume": "14",
@@ -1063,6 +1085,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:dhFuZR0502QC",
                 "title": "Quantifying Carbon Emissions in Cold Chain Transport: A Real-World Data-Driven Approach",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Transportation Research Part D: Transport and Environment",
                 "volume": "142",
@@ -1112,6 +1135,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:L8Ckcad2t8MC",
                 "title": "AI-driven Short-term Load Forecasting Enhanced by Clustering in Multi-type University Buildings: Insights Across Building Types and Pandemic Phases",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Journal of Building Engineering",
                 "volume": "104",
@@ -1157,6 +1181,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:mB3voiENLucC",
                 "title": "Super-Resolution Wind Mapping with Deep Learning for Scalable Renewable Energy Planning",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Communications Earth & Environment",
                 "volume": "7",
@@ -1192,6 +1217,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:digitalization-lca-pod",
                 "title": "Digitalization and decarbonization in last-mile logistics: a life cycle assessment of proof of delivery systems",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Transportation Letters",
                 "volume": "",
@@ -1239,6 +1265,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:boiler-air-pollution-taiwan",
                 "title": "Integrated assessment of boiler air pollution control policy: Impacts on emissions, air quality, and public health in Taiwan",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Atmospheric Pollution Research",
                 "volume": "17",
@@ -1289,6 +1316,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:ecological-economics-2026",
                 "title": "Equity in Carbon Pricing: Impacts on Household Carbon Burdens Across Different Demographics",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Ecological Economics",
                 "volume": "242",
@@ -1336,6 +1364,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:schneider2023comparative",
                 "title": "Comparative Life Cycle Assessment (LCA) on battery electric and combustion engine motorcycles in Taiwan",
+                "toolUrl": "",
                 "link": "https://doi.org/10.1016/j.jclepro.2023.137060",
                 "journal": "Journal of Cleaner Production",
                 "volume": "406",
@@ -1358,6 +1387,7 @@
             {
                 "citationId": "",
                 "title": "Probabilistic Electricity Demand Forecasting for Buildings Using a Variational Mode Decomposition-Attentive Quantile Network",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Energy & Buildings",
                 "volume": "366",
@@ -1404,6 +1434,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:yoo2025sector",
                 "title": "Sector-specific Decarbonization Effects of High-Speed Rails Expansions",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Energy Economics",
                 "volume": "158",
@@ -1456,6 +1487,7 @@
             {
                 "citationId": "",
                 "title": "Digital Transformation and Carbon Redistribution in Warehouse Operations: Evidence from State-Persistent Simulation",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1478,6 +1510,7 @@
             {
                 "citationId": "",
                 "title": "Advancing Circular Logistics: Life Cycle Assessment of Structurally Reinforced Modular Plastic Pallets",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1500,6 +1533,7 @@
             {
                 "citationId": "",
                 "title": "Adaptive and Multifaceted Vehicle-to-Building (V2B) Energy Management: A Two-Stage Framework Addressing User Expectations and Uncertainty",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1522,6 +1556,7 @@
             {
                 "citationId": "",
                 "title": "Optimizing dynamic shared E-moped relocation with long-term effect via deep reinforcement learning",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1544,6 +1579,7 @@
             {
                 "citationId": "",
                 "title": "Decarbonizing First-Mile Cold Chain Freight: Empirical Analysis of Heavy-Duty Refrigerated Truck Operations",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1566,6 +1602,7 @@
             {
                 "citationId": "",
                 "title": "Double Energy Vulnerability in Taiwan: Household Energy Poverty Across Domestic and Transport Domains",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1588,6 +1625,7 @@
             {
                 "citationId": "",
                 "title": "Detection-Guided and Prompt-Augmented Transformers for Automated and Generalizable Cobb Angle Estimation in Spinal Radiographs",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1610,6 +1648,7 @@
             {
                 "citationId": "",
                 "title": "Contrastive Representation Learning for Robust Cross-Site Very Short-Term Photovoltaic Forecasting",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1632,6 +1671,7 @@
             {
                 "citationId": "",
                 "title": "Carbon pricing at the border: Product-level evidence on the impacts of the EU Carbon Border Adjustment Mechanism",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1654,6 +1694,7 @@
             {
                 "citationId": "",
                 "title": "Emission-aware routing for cold-chain last-mile logistics: A data-driven green vehicle routing framework with path-level emission modeling",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1676,6 +1717,7 @@
             {
                 "citationId": "",
                 "title": "淨零轉型下機車電動化的減碳效益：臺灣與中國之比較研究",
+                "toolUrl": "",
                 "link": "",
                 "journal": "",
                 "volume": "",
@@ -1699,6 +1741,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:hsieh2020transitionev",
                 "title": "Transition to Electric Vehicles in China: Implications for Total Cost of Ownership and Cost to Society",
+                "toolUrl": "",
                 "link": "",
                 "journal": "SAE International Journal of Sustainable Transportation, Energy, Environment, & Policy",
                 "volume": "1",
@@ -1742,6 +1785,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:sun2024criticalmaterials",
                 "title": "Reducing supply risk of critical materials for clean energy via foreign direct investment",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Nature Sustainability",
                 "volume": "7",
@@ -1810,6 +1854,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:verma2023voicesroad",
                 "title": "Driving a sustainable road transportation transformation",
+                "toolUrl": "",
                 "link": "",
                 "journal": "One Earth",
                 "volume": "6",
@@ -1868,6 +1913,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:hsieh2020motorizationbattery",
                 "title": "Transition to electric vehicles in China: Implications for private motorization rate and battery market",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Energy Policy",
                 "volume": "144",
@@ -1917,6 +1963,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:hsieh2019batterylearning",
                 "title": "Learning only buys you so much: Practical limits on battery price reduction",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Applied Energy",
                 "volume": "239",
@@ -1968,6 +2015,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:hsieh2020taxifleets",
                 "title": "Recharging systems and business operations to improve the economics of electrified taxi fleets",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Sustainable Cities and Society",
                 "volume": "57",
@@ -2018,6 +2066,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:ou2021iscience2050",
                 "title": "China's vehicle electrification impacts on sales, fuel use, and battery material demand through 2050: Optimizing consumer and industry decisions",
+                "toolUrl": "",
                 "link": "",
                 "journal": "iScience",
                 "volume": "24",
@@ -2076,6 +2125,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:hsieh2022airquality",
                 "title": "An Integrated Assessment of Emissions, Air Quality, and Public Health Impacts of China's Transition to Electric Vehicles",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Environmental Science & Technology",
                 "volume": "56",
@@ -2138,6 +2188,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:hsieh2018uncertaintycarsales",
                 "title": "Incorporating Multiple Uncertainties into Projections of Chinese Private Car Sales and Stock",
+                "toolUrl": "",
                 "link": "",
                 "journal": "Transportation Research Record",
                 "volume": "2672",
@@ -2179,6 +2230,7 @@
             {
                 "citationId": "tUbPb-QAAAAJ:tam2025lcoctaiwan",
                 "title": "Assessment and Sensitivity Analysis of Electric Vehicle Charging Costs in Taiwan: A Levelized Cost Model Approach",
+                "toolUrl": "",
                 "titleZh": "臺灣電動車輛均化充電成本評估與敏感度分析",
                 "link": "https://www.airitilibrary.com/Article/Detail/10177159-N202603270008-00002",
                 "journal": "Transportation Planning Journal",

--- a/templates/pages/publications/publication-item.html
+++ b/templates/pages/publications/publication-item.html
@@ -237,6 +237,18 @@
                         </a>
                         {% endif %}
 
+                        {# Optional interactive companion (e.g. a calculator/demo tool) hosted
+                           on-site. Renders a second action button only when the entry sets
+                           `toolUrl`; same-origin link, so it also gives the tool an internal
+                           link from a page Google already ranks. #}
+                        {% if pub.get('toolUrl') %}
+                        <a class="pub-action-btn skewed-block" b-role="btn" b-hoverable
+                           href="{{ pub['toolUrl'] }}" target="_blank" rel="noopener">
+                            <span>Try the interactive tool</span>
+                            <svg aria-hidden="true"><use href="/assets/sprite.svg#svg-arrow-top-right"></use></svg>
+                        </a>
+                        {% endif %}
+
                         {% if pub.get('doi') %}
                         <p class="pub-item-doi">DOI<span>{{ pub['doi'] }}</span></p>
                         {% endif %}


### PR DESCRIPTION
## Summary
- Add an optional `toolUrl` field + a **"Try the interactive tool"** button on publication detail pages, so on-site interactive tools (calculators, demos) can be surfaced from the paper they belong to.
- First use: the orphaned **Bus-Shelter Solar-PV calculator** (`/Solar-PV-on-Bus-Shelter/`) is now linked from its paper (`2024-bus-shelter-solar-pv-taipei`). This recycles the orphan's search signal (15 impr @ pos 26) via an internal link from a page that already ranks — a strict improvement over the previously-planned 301 redirect, which would have killed a genuinely useful tool.
- `toolUrl` back-filled empty across the other 52 Recent Publications entries to keep the list schema uniform (52 clean insertions, no reformatting).

## SEO report (`SEO/seo-report.html`)
- Dropped the `/research/{topic}/` pages initiative (Action 6 + §4 page-card + all cross-references).
- Moved **Action 8** (orphan tool) into ✓ Done & verified — *linked, not redirected*.
- Reconciled completed items 1–5 + the breadcrumb audit into Done; refreshed publication counts (52 → 53) and other stale stats.

## Verification
- `python build.py` succeeds; the "Try the interactive tool" button renders on the bus-shelter page **only** (1/40 publication pages), alongside "View on publisher", linking to `/Solar-PV-on-Bus-Shelter/`.
- Report HTML div-balanced (276/276); `publications.json` diff is additions-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
