### PR TITLE
style: accessible inline-link color + home Selected-projects row affordance

### DIFF
--- a/static/css/general.css
+++ b/static/css/general.css
@@ -182,6 +182,12 @@ i {
     color: var(--main-color);
 }
 
+/* Editorial inline-link recipe. Sits in the teal family (--link-color is
+   a touch lighter than body --main-color) so the link reads as part of
+   the prose, not a foreign accent. Three cues compound: color shift, bold
+   weight, and a faded currentColor underline. Hover/focus deepens the
+   color to body and solidifies the underline. Visited stays the rest
+   color so navigation history doesn't go purple. */
 :where(
     .abt-text,
     #about .content,
@@ -192,14 +198,16 @@ i {
     .pub-item-abstract,
     .contact-tagline
 ) a {
-    color: var(--main-color-2);
+    color: var(--link-color);
+    font-weight: var(--fw-bold);
     text-decoration: underline;
-    text-decoration-color: color-mix(in srgb, var(--main-color-2) 35%, transparent);
+    text-decoration-color: color-mix(in srgb, currentColor 50%, transparent);
     text-decoration-thickness: 0.0625rem;
     text-underline-offset: 0.2em;
     transition:
-        text-decoration-color 240ms ease-out,
-        color 240ms ease-out;
+        text-decoration-color 200ms ease-out,
+        text-decoration-thickness 200ms ease-out,
+        color 200ms ease-out;
 }
 :where(
     .abt-text,
@@ -210,7 +218,7 @@ i {
     .news-item-body,
     .pub-item-abstract,
     .contact-tagline
-) a:visited { color: var(--main-color-2); }
+) a:visited { color: var(--link-color); }
 
 :where(
     .abt-text,
@@ -232,8 +240,9 @@ i {
     .pub-item-abstract,
     .contact-tagline
 ) a:focus-visible {
+    color: var(--main-color);
     text-decoration-color: currentColor;
-    color: color-mix(in srgb, var(--main-color-2) 75%, var(--main-color));
+    text-decoration-thickness: 0.09375rem;
 }
 
 :where(
@@ -349,6 +358,13 @@ i {
     --main-color-3: #badcea;
     --secondary-color: #c4c691;
     --page-bg-color: #f7fafb;
+
+    /* Inline-prose link color — slightly lighter than --main-color (body)
+       so the link reads as distinct without outweighing the prose it sits
+       in. Used by the unified :where() prose recipe below. Contrast on
+       --page-bg-color: 6.2:1 (AAA). The previous accent --main-color-2
+       (#4caedd) reads at ~2.2:1 and was failing AA for inline use. */
+    --link-color: #1a6489;
 
     --main-color-hsl: 201, 85%, 27%;
 

--- a/static/css/subpage.css
+++ b/static/css/subpage.css
@@ -1669,9 +1669,10 @@
 
 /* Lift the at-rest arrow opacity above the news-subpage default (0.18 →
    0.4) so the "this row leads somewhere" cue is discoverable at rest
-   without hover. Pairs with the cursor:pointer + background tint from
-   the shared .news-row--link rule. */
-.projects-subpage .news-row-arrow {
+   without hover. Scoped to #projects so both the /projects subpage and
+   the homepage "Selected projects" section get the same affordance —
+   both wrappers carry id="projects". */
+#projects .news-row-arrow {
     opacity: 0.4;
     align-self: center;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,9 +57,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400..600&family=Noto+Sans+TC:wght@400..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=31">
+    <link rel="stylesheet" href="/css/general.css?v=32">
     <link rel="stylesheet" href="/css/style.css?v=31">
-    <link rel="stylesheet" href="/css/subpage.css?v=58">
+    <link rel="stylesheet" href="/css/subpage.css?v=59">
 
     <!-- js -->
     <script defer src="/js/general.js?v=4"></script>

--- a/templates/pages/member/member.html
+++ b/templates/pages/member/member.html
@@ -91,8 +91,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400..600&family=Noto+Sans+TC:wght@400..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=31">
-    <link rel="stylesheet" href="/css/subpage.css?v=58">
+    <link rel="stylesheet" href="/css/general.css?v=32">
+    <link rel="stylesheet" href="/css/subpage.css?v=59">
     <link rel="stylesheet" href="/css/member.css?v=27">
 
     <!-- js -->

--- a/templates/pages/news/news-item.html
+++ b/templates/pages/news/news-item.html
@@ -55,8 +55,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400..600&family=Noto+Sans+TC:wght@400..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=31">
-    <link rel="stylesheet" href="/css/subpage.css?v=58">
+    <link rel="stylesheet" href="/css/general.css?v=32">
+    <link rel="stylesheet" href="/css/subpage.css?v=59">
     <link rel="stylesheet" href="/css/news-item.css?v=10">
 
     <!-- js -->

--- a/templates/pages/projects/project-item.html
+++ b/templates/pages/projects/project-item.html
@@ -58,8 +58,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400..600&family=Noto+Sans+TC:wght@400..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=31">
-    <link rel="stylesheet" href="/css/subpage.css?v=58">
+    <link rel="stylesheet" href="/css/general.css?v=32">
+    <link rel="stylesheet" href="/css/subpage.css?v=59">
     <link rel="stylesheet" href="/css/project-item.css?v=15">
 
     <!-- js -->

--- a/templates/pages/publications/publication-item.html
+++ b/templates/pages/publications/publication-item.html
@@ -52,8 +52,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400..600&family=Noto+Sans+TC:wght@400..600&display=swap" rel="stylesheet" crossorigin>
 
     <!-- css -->
-    <link rel="stylesheet" href="/css/general.css?v=31">
-    <link rel="stylesheet" href="/css/subpage.css?v=58">
+    <link rel="stylesheet" href="/css/general.css?v=32">
+    <link rel="stylesheet" href="/css/subpage.css?v=59">
     <link rel="stylesheet" href="/css/publication-item.css?v=11">
 
     <!-- js -->


### PR DESCRIPTION
## Summary
- **Accessible inline links:** introduce \`--link-color: #1a6489\` for the inline-prose link recipe in \`general.css\`. The previous accent \`--main-color-2\` (#4caedd) read at **~2.2:1** against \`--page-bg-color\` and was failing WCAG AA; the new color hits **6.2:1 (AAA)**. Recipe gains \`font-weight: bold\` and a currentColor-derived underline; \`:focus-visible\` deepens to body color with a thicker underline. Visited links stay in \`--link-color\` to avoid the purple navigation tell.
- **Row affordance on home:** widen the \`.news-row-arrow\` at-rest opacity lift (0.18 → 0.4) from \`.projects-subpage\` to \`#projects\` so the homepage "Selected projects" section (which also carries \`id="projects"\`) gets the same discoverable cue as \`/projects/\`.
- **Cache bust:** bump \`general.css\` v=31→32 and \`subpage.css\` v=58→59 in \`base.html\` and the four detail-page templates.

## Test plan
- [ ] \`python build.py\` produces clean \`docs/\` output
- [ ] Inline links in About / news bodies / publication abstracts / contact tagline render in teal-leaning blue, bold, with a soft underline; hover/focus deepens to body color with thicker underline
- [ ] Visited links stay in \`--link-color\` (no purple)
- [ ] Verify contrast ≥ 4.5:1 in browser devtools' accessibility inspector
- [ ] On the homepage, "Selected projects" rows now show the arrow at 0.4 opacity at rest (matches \`/projects/\`)
- [ ] Hard refresh or fresh load picks up the new CSS (v=32 / v=59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)